### PR TITLE
Now, ROIs do not contain unmapped pixels.

### DIFF
--- a/ahcore/losses.py
+++ b/ahcore/losses.py
@@ -100,6 +100,7 @@ def cross_entropy(
     torch.Tensor
         Output as a torch.Tensor float
     """
+    corrected_roi = None
     if limit is not None:
         if limit >= 0:
             raise ValueError(f"Limit has to be a negative value. Got {limit}")
@@ -109,7 +110,12 @@ def cross_entropy(
             raise ValueError(f"topk value needs to be between 0 and 1. Got {topk}.")
 
     if roi is not None:
-        roi_sum = roi.sum() / input.shape[0]
+        # Correct the ROI to remove any unannotated regions (see github issue #11)
+        background = (target[:, 0, :, :] == 1).int()
+        corrected_roi = roi.squeeze(1) - background
+        # Clip the values below 0 after the subtraction.
+        corrected_roi[corrected_roi < 0] = 0
+        roi_sum = corrected_roi.sum() / input.shape[0]
         if roi_sum == 0:
             return torch.Tensor([0.0]).to(input.device)
     else:
@@ -130,8 +136,8 @@ def cross_entropy(
     if limit is not None:
         _cross_entropy = torch.clip(_cross_entropy, limit, None)
 
-    if roi is not None:
-        _cross_entropy = roi[:, 0, ...] * _cross_entropy
+    if corrected_roi is not None:
+        _cross_entropy = corrected_roi * _cross_entropy
 
     if topk is None:
         return _cross_entropy.sum(dim=(1, 2)) / roi_sum
@@ -210,8 +216,13 @@ def soft_dice(
 
     # Apply the ROI if it is there
     if roi is not None:
-        input = roi * input
-        target = roi * target
+        # Correct the ROI to remove any unannotated regions (see github issue #11)
+        background = (target[:, 0, :, :] == 1).int()
+        corrected_roi = (roi.squeeze(1) - background).unsqueeze(1)
+        # Clip the values below 0 after the subtraction.
+        corrected_roi[corrected_roi < 0] = 0
+        input = corrected_roi * input
+        target = corrected_roi * target
 
     # Softmax still needs to be taken (logits are outputted by the network)
     input_soft = F.softmax(input, dim=1)

--- a/ahcore/metrics.py
+++ b/ahcore/metrics.py
@@ -255,10 +255,15 @@ class WSIMetricFactory:
 def _get_intersection_and_cardinality(
     predictions: torch.Tensor, target: torch.Tensor, roi: torch.Tensor | None, num_classes: int
 ) -> List[Tuple[torch.Tensor, torch.Tensor]]:
+
     soft_predictions = F.softmax(predictions, dim=1)
-    # if roi is not None:
-    #     soft_predictions = soft_predictions * roi
-    #     target = target * roi
+    corrected_roi = None
+    if roi is not None:
+        # Correct the ROI to remove any unannotated regions (see github issue #11)
+        background = (target[:, 0, :, :] == 1).int()
+        corrected_roi = roi.squeeze(1) - background
+        # Clip the values below 0 after the subtraction.
+        corrected_roi[corrected_roi < 0] = 0
 
     predictions = soft_predictions.argmax(dim=1)
     _target = target.argmax(dim=1)
@@ -268,10 +273,10 @@ def _get_intersection_and_cardinality(
         curr_predictions = (predictions == class_idx).int()
         curr_target = (_target == class_idx).int()
         # Compute the dice score
-        if roi is not None:
-            intersection = torch.sum((curr_predictions * curr_target) * roi.squeeze(1), dim=(0, 1, 2))
-            cardinality = torch.sum(curr_predictions * roi.squeeze(1), dim=(0, 1, 2)) + torch.sum(
-                curr_target * roi.squeeze(1), dim=(0, 1, 2)
+        if corrected_roi is not None:
+            intersection = torch.sum((curr_predictions * curr_target) * corrected_roi, dim=(0, 1, 2))
+            cardinality = torch.sum(curr_predictions * corrected_roi, dim=(0, 1, 2)) + torch.sum(
+                curr_target * corrected_roi, dim=(0, 1, 2)
             )
         else:
             intersection = torch.sum((curr_predictions * curr_target), dim=(0, 1, 2))


### PR DESCRIPTION
Fixes {#11}

Following from the issue mentioned above, I have corrected how the loss and metrics are calculated. See below for a visual explanation.

![ROI_correction](https://user-images.githubusercontent.com/26798611/221040106-b21fd488-8736-4384-bf11-d775e51c25ab.png)

This correction has led to Dice score for the background behaving as expected. After the ROI correction, both the intersection and cardinality are 0 during Dice metric computation. Whenever there is a `nan` in the dice, we replace it with `1.0` in ahcore. See [here](https://github.com/NKI-AI/ahcore/blob/69916fc8f2967444f13e23d97738f24f86503054/ahcore/metrics.py#L285).

![image](https://user-images.githubusercontent.com/26798611/221040544-63e8c491-416b-44f2-acec-3a5439b85524.png)
