### PR TITLE
Fixes/macenko

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,3 +119,4 @@ dlup/preprocessors/tests/data/test_output
 tools/logs
 config/machine_settings/*
 !config/machine_settings/example.yaml
+/ahcore/models/attention_unet.py

--- a/ahcore/data/dataset.py
+++ b/ahcore/data/dataset.py
@@ -133,16 +133,16 @@ class DlupDataModule(pl.LightningDataModule):
 
         if self.data_description.compute_staining is True:
             path_to_dump_stains = (
-                Path(os.environ.get("SCRATCH", "/tmp")) / "ahcore_cache" / stage.value / "staining_parameters"
+                Path(os.environ.get("SCRATCH", "/tmp")) / "ahcore_cache" / "staining_parameters"
             )
-            if path_to_dump_stains.is_dir():
-                logger.info(f"Staining vectors for all images in {stage} stage are already cached...")
-            else:
-                logger.info(f"Computing staining vectors for all images in {stage} stage...")
-                stain_computer = MacenkoNormalizer(return_stains=False)
-                wsi_transformation = transforms.Compose([transforms.PILToTensor()])
-                for manifest in manifests:
-                    image_fn, _, overwrite_mpp = parse_wsi_attributes_from_manifest(self.data_description, manifest)
+            stain_computer = MacenkoNormalizer(return_stains=False)
+            wsi_transformation = transforms.Compose([transforms.PILToTensor()])
+            for manifest in manifests:
+                image_fn, _, overwrite_mpp = parse_wsi_attributes_from_manifest(self.data_description, manifest)
+                if (path_to_dump_stains / (image_fn.stem + ".h5")).is_file():
+                    logger.info(f"Staining vectors stage {image_fn.stem} are already cached...")
+                    continue
+                else:
                     slide_image = SlideImage.from_file_path(image_fn, overwrite_mpp=overwrite_mpp)
                     rescaled_wsi = slide_image.get_scaled_view(slide_image.get_scaling(16))
                     thumbnail = slide_image.get_thumbnail(size=rescaled_wsi.size).convert("RGB")

--- a/ahcore/data/dataset.py
+++ b/ahcore/data/dataset.py
@@ -140,7 +140,7 @@ class DlupDataModule(pl.LightningDataModule):
             for manifest in manifests:
                 image_fn, _, overwrite_mpp = parse_wsi_attributes_from_manifest(self.data_description, manifest)
                 if (path_to_dump_stains / (image_fn.stem + ".h5")).is_file():
-                    logger.info(f"Staining vectors stage {image_fn.stem} are already cached...")
+                    logger.info(f"Staining vectors for {image_fn.stem} are already cached...")
                     continue
                 else:
                     slide_image = SlideImage.from_file_path(image_fn, overwrite_mpp=overwrite_mpp)

--- a/ahcore/data/dataset.py
+++ b/ahcore/data/dataset.py
@@ -33,14 +33,15 @@ class DlupDataModule(pl.LightningDataModule):
     """Datamodule for the Ahcore framework. This datamodule is based on `dlup`."""
 
     def __init__(
-        self,
-        data_description: DataDescription,
-        pre_transform: Callable,
-        batch_size: int = 32,  # noqa,pylint: disable=unused-argument
-        validate_batch_size: int | None = None,  # noqa,pylint: disable=unused-argument
-        num_workers: int = 16,
-        persistent_workers: bool = False,
-        pin_memory: bool = False,
+            self,
+            data_description: DataDescription,
+            pre_transform: Callable,
+            batch_size: int = 32,  # noqa,pylint: disable=unused-argument
+            validate_batch_size: int | None = None,  # noqa,pylint: disable=unused-argument
+            num_workers: int = 16,
+            persistent_workers: bool = False,
+            pin_memory: bool = False,
+            compute_staining: bool = False,
     ) -> None:
         """
         Construct a DataModule based on a manifest.
@@ -87,6 +88,7 @@ class DlupDataModule(pl.LightningDataModule):
 
         self._batch_size = self.hparams.batch_size  # type: ignore
         self._validate_batch_size = self.hparams.validate_batch_size  # type: ignore
+        self._compute_staining = compute_staining
 
         mask_threshold = data_description.mask_threshold
         if mask_threshold is None:
@@ -131,9 +133,9 @@ class DlupDataModule(pl.LightningDataModule):
         tile_overlap = grid.tile_overlap
         output_tile_size = getattr(grid, "output_tile_size", None)
 
-        if self.data_description.compute_staining is True:
+        if self._compute_staining is True:
             path_to_dump_stains = (
-                Path(os.environ.get("SCRATCH", "/tmp")) / "ahcore_cache" / "staining_parameters"
+                    Path(os.environ.get("SCRATCH", "/tmp")) / "ahcore_cache" / "staining_parameters"
             )
             stain_computer = MacenkoNormalizer(return_stains=False)
             wsi_transformation = transforms.Compose([transforms.PILToTensor()])
@@ -224,7 +226,7 @@ class DlupDataModule(pl.LightningDataModule):
         return obj
 
     def _construct_dataloader_iterator(
-        self, data_iterator, batch_size: int
+            self, data_iterator, batch_size: int
     ) -> Iterator[tuple[dict[str, Any], DataLoader]] | None:
         if not data_iterator:
             return None
@@ -232,8 +234,8 @@ class DlupDataModule(pl.LightningDataModule):
         test_description = self.data_description.inference_grid
         # TODO: This should be somewhere where we validate the configuration
         if (
-            test_description.output_tile_size is not None
-            and test_description.output_tile_size != test_description.tile_size
+                test_description.output_tile_size is not None
+                and test_description.output_tile_size != test_description.tile_size
         ):
             raise ValueError(f"`output_tile_size should be equal to tile_size in inference or set to None.")
 

--- a/ahcore/data/dataset.py
+++ b/ahcore/data/dataset.py
@@ -140,9 +140,7 @@ class DlupDataModule(pl.LightningDataModule):
             else:
                 logger.info(f"Computing staining vectors for all images in {stage} stage...")
                 stain_computer = MacenkoNormalizer(return_stains=False)
-                wsi_transformation = transforms.Compose(
-                    [transforms.PILToTensor()]
-                )
+                wsi_transformation = transforms.Compose([transforms.PILToTensor()])
                 for manifest in manifests:
                     image_fn, _, overwrite_mpp = parse_wsi_attributes_from_manifest(self.data_description, manifest)
                     slide_image = SlideImage.from_file_path(image_fn, overwrite_mpp=overwrite_mpp)

--- a/ahcore/data/dataset.py
+++ b/ahcore/data/dataset.py
@@ -20,8 +20,11 @@ import ahcore.data.samplers
 from ahcore.transforms.image_normalization import MacenkoNormalizer
 from ahcore.utils.data import DataDescription, create_inference_metadata, dataclass_to_uuid
 from ahcore.utils.io import get_logger
-from ahcore.utils.manifest import image_manifest_to_dataset, manifests_from_data_description, \
-    parse_wsi_attributes_from_manifest
+from ahcore.utils.manifest import (
+    image_manifest_to_dataset,
+    manifests_from_data_description,
+    parse_wsi_attributes_from_manifest,
+)
 
 logger = get_logger(__name__)
 
@@ -30,14 +33,14 @@ class DlupDataModule(pl.LightningDataModule):
     """Datamodule for the Ahcore framework. This datamodule is based on `dlup`."""
 
     def __init__(
-            self,
-            data_description: DataDescription,
-            pre_transform: Callable,
-            batch_size: int = 32,  # noqa,pylint: disable=unused-argument
-            validate_batch_size: int | None = None,  # noqa,pylint: disable=unused-argument
-            num_workers: int = 16,
-            persistent_workers: bool = False,
-            pin_memory: bool = False,
+        self,
+        data_description: DataDescription,
+        pre_transform: Callable,
+        batch_size: int = 32,  # noqa,pylint: disable=unused-argument
+        validate_batch_size: int | None = None,  # noqa,pylint: disable=unused-argument
+        num_workers: int = 16,
+        persistent_workers: bool = False,
+        pin_memory: bool = False,
     ) -> None:
         """
         Construct a DataModule based on a manifest.
@@ -129,24 +132,26 @@ class DlupDataModule(pl.LightningDataModule):
         output_tile_size = getattr(grid, "output_tile_size", None)
 
         if self.data_description.compute_staining is True:
-            path_to_dump_stains = Path(os.environ.get("SCRATCH", "/tmp")) / "ahcore_cache" / stage.value / "staining_parameters"
+            path_to_dump_stains = (
+                Path(os.environ.get("SCRATCH", "/tmp")) / "ahcore_cache" / stage.value / "staining_parameters"
+            )
             if path_to_dump_stains.is_dir():
                 logger.info(f"Staining vectors for all images in {stage} stage are already cached...")
             else:
                 logger.info(f"Computing staining vectors for all images in {stage} stage...")
                 stain_computer = MacenkoNormalizer(return_stains=False)
-                wsi_transformation = transforms.Compose([
-                    transforms.PILToTensor(),
-                    transforms.Lambda(lambda x: x * 255)
-                ])
+                wsi_transformation = transforms.Compose(
+                    [transforms.PILToTensor()]
+                )
                 for manifest in manifests:
                     image_fn, _, overwrite_mpp = parse_wsi_attributes_from_manifest(self.data_description, manifest)
                     slide_image = SlideImage.from_file_path(image_fn, overwrite_mpp=overwrite_mpp)
                     rescaled_wsi = slide_image.get_scaled_view(slide_image.get_scaling(16))
                     thumbnail = slide_image.get_thumbnail(size=rescaled_wsi.size).convert("RGB")
-                    # We need unsqueeze to mimic a batch dimension.
                     rescaled_wsi_tensor = wsi_transformation(thumbnail).unsqueeze(0)
-                    stain_computer.fit(wsi=rescaled_wsi_tensor, wsi_name=image_fn.stem, dump_to_folder=path_to_dump_stains)
+                    stain_computer.fit(
+                        wsi=rescaled_wsi_tensor, wsi_name=image_fn.stem, dump_to_folder=path_to_dump_stains
+                    )
 
         def dataset_iterator() -> Iterator[Dataset]:
             for image_manifest in manifests:
@@ -221,7 +226,7 @@ class DlupDataModule(pl.LightningDataModule):
         return obj
 
     def _construct_dataloader_iterator(
-            self, data_iterator, batch_size: int
+        self, data_iterator, batch_size: int
     ) -> Iterator[tuple[dict[str, Any], DataLoader]] | None:
         if not data_iterator:
             return None
@@ -229,8 +234,8 @@ class DlupDataModule(pl.LightningDataModule):
         test_description = self.data_description.inference_grid
         # TODO: This should be somewhere where we validate the configuration
         if (
-                test_description.output_tile_size is not None
-                and test_description.output_tile_size != test_description.tile_size
+            test_description.output_tile_size is not None
+            and test_description.output_tile_size != test_description.tile_size
         ):
             raise ValueError(f"`output_tile_size should be equal to tile_size in inference or set to None.")
 

--- a/ahcore/entrypoints.py
+++ b/ahcore/entrypoints.py
@@ -13,7 +13,7 @@ import hydra
 import torch
 from omegaconf import DictConfig
 from pytorch_lightning import Callback, LightningDataModule, LightningModule, Trainer, seed_everything
-from pytorch_lightning.loggers import LightningLoggerBase
+from pytorch_lightning.loggers import Logger
 from torch import nn
 
 from ahcore.utils.data import DataDescription
@@ -121,7 +121,7 @@ def train(config: DictConfig) -> torch.Tensor | None:
                 callbacks.append(hydra.utils.instantiate(cb_conf))
 
     # Init lightning loggers
-    lightning_loggers: list[LightningLoggerBase] = []
+    lightning_loggers: list[Logger] = []
     if "logger" in config:
         for _, lg_conf in config.logger.items():
             if "_target_" in lg_conf:
@@ -245,7 +245,7 @@ def inference(config: DictConfig) -> None:
                 callbacks.append(hydra.utils.instantiate(cb_conf))
 
     # Init lightning loggers
-    lightning_loggers: list[LightningLoggerBase] = []
+    lightning_loggers: list[Logger] = []
     if "logger" in config:
         for _, lg_conf in config.logger.items():
             if "_target_" in lg_conf:

--- a/ahcore/lit_module.py
+++ b/ahcore/lit_module.py
@@ -11,7 +11,7 @@ from functools import partial
 from multiprocessing import Process, Queue
 from pathlib import Path
 from typing import Any
-
+from dlup._image import Resampling
 import numpy as np
 import pytorch_lightning as pl
 import torch.nn.functional as F
@@ -351,6 +351,7 @@ class AhCoreLightningModule(pl.LightningModule):
                 pyramid=True,
                 compression=TiffCompression("jpeg"),
                 quality=100,
+                interpolator=Resampling.NEAREST,
             )
             self._new_val_wsi = False
             self._predictions_queue.put(

--- a/ahcore/lit_module.py
+++ b/ahcore/lit_module.py
@@ -81,9 +81,16 @@ class AhCoreLightningModule(pl.LightningModule):
         self._augmentations = augmentations
 
         self._loss = loss
+        self._robustness_metrics = []
         if metrics is not None:
             self._metrics = metrics.get("tile_level")
             self._wsi_metrics = metrics.get("wsi_level")
+            if "prediction_robustness" in metrics:
+                self._robustness_metrics.append(metrics["prediction_robustness"])
+            if "feature_robustness" in metrics:
+                self._robustness_metrics.append(metrics["feature_robustness"])
+            if "linear_probing" in metrics:
+                self._robustness_metrics.append(metrics["linear_probing"])
 
         self._plot_batch = partial(plot_batch, index_map=data_description.index_map, colors=data_description.colors)
         if not trackers:
@@ -168,7 +175,12 @@ class AhCoreLightningModule(pl.LightningModule):
         # ROIs can reduce the usable area of the inputs, the loss should be scaled appropriately
         roi = batch.get("roi", None)
 
-        _prediction = self._model(_input)
+        if self._model.return_features:
+            _prediction, _features = self._model(_input)
+            batch["features"] = _features
+        else:
+            _prediction = self._model(_input)
+        batch["prediction"] = _prediction
         loss = self._loss(_prediction, _target, roi)
         # The relevant_dict contains values to know where the tiles originate.
         _relevant_dict = {k: v for k, v in batch.items() if k in self.RELEVANT_KEYS}
@@ -185,7 +197,8 @@ class AhCoreLightningModule(pl.LightningModule):
         if stage == stage.VALIDATING:  # Create tiles iterator and process metrics
             current_wsi_filename = self._get_current_val_wsi_filename()
             self._process_wsi_metrics(_prediction, _target, str(current_wsi_filename), roi)
-
+            for robustness_metric in self._robustness_metrics:
+                robustness_metric.update(batch)
             # add the current predictions to the queue, to be processed by the tiff writer process
             curr_val_dataset, num_grid_tiles = self._get_current_val_dataset(return_num_tiles=True)
 
@@ -258,6 +271,10 @@ class AhCoreLightningModule(pl.LightningModule):
         return output
 
     def on_validation_epoch_end(self) -> None:
+        if len(self._robustness_metrics) > 0:
+            for robustness_metric in self._robustness_metrics:
+                self.log_dict(robustness_metric.compute(), sync_dist=True, prog_bar=True)
+                robustness_metric.reset()
         "Adds a marker _WSI_DONE for the last WSI and LOOP_DONE flag to the queue and waits for child process to finish"
         self._predictions_queue.put(
             [{"tile_shape": self._tile_shape}, _WSI_DONE, None]

--- a/ahcore/metrics/__init__.py
+++ b/ahcore/metrics/__init__.py
@@ -1,0 +1,12 @@
+from ahcore.metrics.epoch_metrics import FeatureAUCRobustness, LinearModelFeatureRobustness, PredictionAUCRobustness
+from ahcore.metrics.metrics import AhCoreMetric, DiceMetric, MetricFactory
+from ahcore.metrics.metrics import WSIMetricFactory
+
+__all__ = [
+    "AhCoreMetric",
+    "DiceMetric",
+    "MetricFactory",
+    "PredictionAUCRobustness",
+    "FeatureAUCRobustness",
+    "LinearModelFeatureRobustness",
+]

--- a/ahcore/metrics/auc.py
+++ b/ahcore/metrics/auc.py
@@ -1,0 +1,40 @@
+""" AUC-based metrics """
+
+import numpy as np
+from sklearn import metrics
+
+
+def standardized_auc(fpr: np.ndarray, tpr: np.ndarray, **kwargs):
+    """
+
+    Parameters
+    ----------
+    fpr: np.ndarray, FP ratios
+    tpr: np.ndarray, TP ratios
+
+    Returns
+    -------
+    standardized AUC; for values below 0.5, 1 - AUC will be returned, so that the result is always >= 0.5
+    """
+    auc = metrics.auc(fpr, tpr)
+    if auc < 0.5:
+        auc = 1.0 - auc  # equivalently, return the AUC for the opposing class
+    return auc
+
+
+def robustness_auc(X: np.ndarray, y: np.ndarray, **kwargs) -> np.ndarray:
+    """calculate the robustness AUC; i.e. the AUC resulting from using feature values as category predictors.
+    Args:
+        X: array-like or sparse matrix, shape (n_samples, n_features), feature matrix
+        y: array-like of shape (n_samples,), Target vector, has to be discrete
+        **kwargs: to be passed to mutual_info_classif
+    Returns: auc, ndarray, shape (n_features,) for each combination of feature and the target category.
+    """
+
+    nr_features = X.shape[1]
+    auc_per_feature = []
+    for feature_index in range(nr_features):
+        fpr, tpr, thresholds = metrics.roc_curve(y, X[:, feature_index], pos_label=True)
+        auc = standardized_auc(fpr, tpr, **kwargs)
+        auc_per_feature.append(auc)
+    return np.array(auc_per_feature)

--- a/ahcore/metrics/epoch_metrics.py
+++ b/ahcore/metrics/epoch_metrics.py
@@ -1,0 +1,283 @@
+"""Metrics that are calculated and tracked only at the end of an epoch"""
+from typing import List
+
+import numpy as np
+import torch
+import torchmetrics
+
+from ahcore.metrics.auc import robustness_auc  # noqa
+from ahcore.metrics.linear_probing import LinearProbing
+from ahcore.utils.data import DataDescription
+from torchmetrics.functional.classification import binary_auroc
+
+_TORCH: str = "torch"
+_NUMPY: str = "numpy"
+_STR_TO_FUNC = {
+    "mean": {_TORCH: torch.mean, _NUMPY: np.mean},
+    "max": {_TORCH: torch.max, _NUMPY: np.max},
+}
+_FEATURE = "features"
+_PRED = "prediction"
+
+EpochMetric = torchmetrics.Metric
+"""Base class of epoch metrics."""
+
+
+class PerTargetMetric(EpochMetric):
+    """Base class for per target epoch metrics.
+
+    Args:
+        target_key: indicates the target with respect to which the robustness metrics are computed,
+            e.g. "center"
+        target_aggregations: list of strings indicating the aggregation statistics to be computed
+            over targets. For example, when `target_key`="center", on top of having the desired
+            metric per target, one will additionally also compute statistics (e.g. mean, std) over
+            all centers and add these as separate metrics.
+
+    Note: The base class expects that every derived class will implement the following methods:
+        get_over_targets_metric_prefix - constructs the prefix of the metric names that will be used
+            for tracking robustness metrics over all targets, e.g. "robustness-of-pred-over-centers"
+        get_aggregation_metric_suffix - for each over targets aggregation statistic (e.g. mean of
+            all per center values) constructs the suffix of the metric corresponding to that
+            aggregation (e.g. "auc-mean")
+    """
+
+    def __init__(self, target_key: str, target_aggregations: List[str]) -> None:
+        super().__init__()
+        self.target_key = target_key
+        self.target_aggregations = target_aggregations
+        self.encoding_to_name: dict[int, str] = {}
+        self.over_targets_metric_prefix = self.get_over_targets_metric_prefix()
+
+    def compute_statistics_over_targets(self, per_target_metrics: List[torch.Tensor]) -> dict[str, torch.Tensor]:
+        """Adds the statistics by aggregating over all targets"""
+        stats = {}
+        per_target_metrics = [
+            a.detach().cpu().numpy() if isinstance(a, torch.Tensor) else a for a in per_target_metrics
+        ]
+        for aggregation in self.target_aggregations:
+            metric_name_suffix = self.get_aggregation_metric_suffix(aggregation)
+            metric_name = self.over_targets_metric_prefix + metric_name_suffix
+            agg_func = getattr(np, aggregation)
+            metric_value = agg_func(per_target_metrics)
+            stats[metric_name] = metric_value
+        return stats
+
+    def get_over_targets_metric_prefix(self) -> str:
+        """To be overwritten by derived classes"""
+        raise NotImplementedError
+
+    def get_aggregation_metric_suffix(self, aggregation: str) -> str:
+        """To be overwritten by derived classes"""
+        raise NotImplementedError
+
+    def get_encoding_to_name(self, batch: dict) -> None:
+        """Updates self.econding_to_name using the values in `batch`.
+        If an encoding is used for multiple targets, all those targets are aggregated under
+        a default name 'all_other_targets'.
+        """
+
+        for name, encoding in zip(*batch[self.target_key]):  # type: ignore
+            encoding = encoding.item()
+            if encoding in self.encoding_to_name and self.encoding_to_name[encoding] != name:
+                self.encoding_to_name[encoding] = f"all_other_{self.target_key}s"
+            else:
+                self.encoding_to_name[encoding] = name
+
+
+class PredictionAUCRobustness(PerTargetMetric):
+    """Tracks AUC between predictions and a chosen target (e.g. center)
+
+    On top of the base-class arguments, the following args are expected
+        predictions_aggregation: indicates how an image batch of shape (B, * H, W) should be
+            aggregated per-patch (e.g. mean of all values in (C, H, W) dimensions). The output after
+            applying this operation is of shape (B,)
+
+    """
+
+    def __init__(
+            self,
+            target_key: str = "center",
+            predictions_aggregation: str = "mean",
+            target_aggregations: List[str] = ["min", "max", "mean", "std"],
+            data_description: DataDescription = None,
+    ):
+        super().__init__(target_key=target_key, target_aggregations=target_aggregations)
+        self.predictions_aggregation = predictions_aggregation
+        self.add_state(name="targets", default=[])
+        self.add_state(name="predictions", default=[])
+
+        self.metric = binary_auroc
+        self.per_target_metric_prefix = f"robustness-of-pred-per-{self.target_key}/"
+        self.name = "PredictionAUCRobustness"
+
+    def update(self, batch: dict) -> None:
+        self.get_encoding_to_name(batch)
+        self.targets += [torch.flatten(batch[self.target_key][1])]  # type: ignore  # shape (B,)
+        # aggregate the (h,w) component of each input according to the input aggregation
+        aggregation_func = _STR_TO_FUNC[self.predictions_aggregation][_TORCH]
+        predictions_batch = batch[_PRED]
+        dim = tuple(i for i in range(1, len(predictions_batch.shape)))
+        self.predictions += [aggregation_func(predictions_batch, dim=dim)]  # type: ignore
+
+    def compute(self) -> dict:
+        predictions = torch.cat(self.predictions, dim=0)  # type: ignore
+        y = torch.cat(self.targets, dim=0)  # type: ignore
+        aucs = {}
+        for target_encoding in torch.unique(y):
+            targets = target_encoding == y
+            target_name = self.encoding_to_name[target_encoding.item()]
+            metric_name_suffix = f"auc-{target_name}"
+            metric_name = self.per_target_metric_prefix + metric_name_suffix
+            aucs[metric_name] = self.metric(predictions, targets)
+
+        aucs.update(self.compute_statistics_over_targets(list(aucs.values())))
+        return aucs
+
+    def get_aggregation_metric_suffix(self, aggregation: str) -> str:
+        """Overwrites base class with desired suffix"""
+        return f"auc-{aggregation}"
+
+    def get_over_targets_metric_prefix(self) -> str:
+        """Overwrites base class with desired prefix"""
+        return f"robustness-of-pred-over-{self.target_key}s/"
+
+
+class FeatureAUCRobustness(PerTargetMetric):
+    """Tracks AUC between patch-level feature aggregation and chosen target
+
+    On top of the base-class arguments, the following args are expected
+        feature_layer: integer indicating which features layer to be used from the encoder
+            (0 = last layer)
+        features_patch_aggregation: for a features batch of shape (B, C, H, W), it indicates the
+            aggregation over the last two dimensions. The output after applying this operation is of
+            shape (B, C)
+        features_per_target_aggregation: after applying features_patch_aggregation and computing the
+            auc per target, we get for each target a tensor of dimension equal to C = num features.
+            This string indicates how to aggregate this tensor into one statistic.
+
+    """
+
+    def __init__(
+            self,
+            target_key: str = "center",
+            feature_layer: int = 0,
+            features_patch_aggregation: str = "mean",
+            features_per_target_aggregation: str = "mean",
+            target_aggregations: List[str] = ["min", "max", "mean", "std"],
+            data_description: DataDescription = None,
+    ):
+        super().__init__(target_key=target_key, target_aggregations=target_aggregations)
+        self.feature_layer = feature_layer
+        self.features_patch_aggregation = features_patch_aggregation
+        self.features_per_target_aggregation = features_per_target_aggregation
+        self.add_state(name="features", default=[])
+        self.add_state(name="targets", default=[])
+
+        self.per_target_metric_prefix = f"robustness-of-feat-per-{self.target_key}/"
+
+    def update(self, batch: dict) -> None:
+        self.get_encoding_to_name(batch)
+        self.targets += [torch.flatten(batch[self.target_key][1])]  # type: ignore  # shape (B,)
+        # aggregate the (h,w) component of each input according to the input aggregation
+        aggregation_func = _STR_TO_FUNC[self.features_patch_aggregation][_TORCH]
+        input_batch = batch[_FEATURE][self.feature_layer]
+        self.features += [aggregation_func(input_batch, dim=(-2, -1))]  # type: ignore
+
+    def compute(self) -> dict:
+        features = torch.cat(self.features, dim=0).detach().cpu().numpy()  # type: ignore
+        y = torch.cat(self.targets, dim=0).detach().cpu().numpy()  # type: ignore
+        aucs = {}
+        for target_encoding in np.unique(y):
+            targets = target_encoding == y
+            target_name = self.encoding_to_name[target_encoding.item()]
+            metric_name_suffix = f"auc-{target_name}"
+            metric_name = self.per_target_metric_prefix + metric_name_suffix
+            aucs[metric_name] = robustness_auc(features, targets)
+            # reduce per-target metric from a tensor of (num_features) to one value
+            per_target_reduction = _STR_TO_FUNC[self.features_per_target_aggregation][_NUMPY]
+            aucs[metric_name] = per_target_reduction(aucs[metric_name])
+
+        aucs.update(self.compute_statistics_over_targets(list(aucs.values())))
+        return aucs
+
+    def get_aggregation_metric_suffix(self, aggregation: str) -> str:
+        """Overwrites base class with desired suffix"""
+        return f"auc-{aggregation}"
+
+    def get_over_targets_metric_prefix(self) -> str:
+        """Overwrites base class with desired prefix"""
+        return f"robustness-of-feat-over-{self.target_key}s/"
+
+
+class LinearModelFeatureRobustness(PerTargetMetric):
+    """Model-level AUC between features and a chosen target (e.g. center) using a linear model.
+    The class reports metrics per target and aggregation across targets by desired statistics (e.g.
+    min, max, mean, std)
+
+    On top of the base-class arguments, the following args are expected:
+        feature_layer: integer indicating which features layer to be used from the encoder
+            (0 = last layer)
+        features_patch_aggregation: for a features batch of shape (B, C, H, W), it indicates the
+            aggregation over the last two dimensions. The output after applying this operation is of
+            shape (B, C)
+        model_name: name of the linear model to be used
+        test_size: test size to be used by the linear model
+        scoring: scoring to be used by the linear model
+        **kwargs: further kwargs to be passed to the linear model
+    """
+
+    def __init__(
+            self,
+            target_key: str = "center",
+            feature_layer: int = 0,
+            features_patch_aggregation: str = "mean",
+            target_aggregations: List[str] = ["min", "max", "mean", "std"],
+            model_name: str = "LogisticRegression",
+            test_size: float = 0.3,
+            scoring: str = "accuracy",
+            data_description: DataDescription = None,
+            **kwargs,
+    ):
+        super().__init__(target_key=target_key, target_aggregations=target_aggregations)
+        self.feature_layer = feature_layer
+        self.features_patch_aggregation = features_patch_aggregation
+        self.add_state(name="targets", default=[])
+        self.add_state(name="features", default=[])
+
+        self.linear_prober = LinearProbing(model_name=model_name, test_size=test_size, scoring=scoring, **kwargs)
+
+        self.per_target_metric_prefix = f"robustness-of-linear-model-per-{self.target_key}/"
+
+    def update(self, batch: dict) -> None:
+        self.get_encoding_to_name(batch)
+        self.targets += [torch.flatten(batch[self.target_key][1])]  # type: ignore  # shape (B,)
+        # aggregate the (h,w) component of each input according to the input aggregation
+        aggregation_func = _STR_TO_FUNC[self.features_patch_aggregation][_TORCH]
+        input_batch = batch[_FEATURE][self.feature_layer]
+        self.features += [aggregation_func(input_batch, dim=(-2, -1))]  # type: ignore
+
+    def compute(self) -> dict:
+        # identify number of features (=num of channels)
+        inputs = torch.cat(self.features, dim=0)  # type: ignore
+        targets = torch.cat(self.targets, dim=0)  # type: ignore
+
+        # compute auc per center
+        aucs = {}
+        for target_encoding in torch.unique(targets):
+            y = target_encoding == targets
+            target_name = self.encoding_to_name[target_encoding.item()]
+            metric_name_suffix = f"patch-{self.features_patch_aggregation}-feat-rob-auc-{target_name}"
+            metric_name = self.per_target_metric_prefix + metric_name_suffix
+            aucs[metric_name] = self.linear_prober(inputs, y)
+
+        aucs.update(self.compute_statistics_over_targets(list(aucs.values())))
+        return aucs
+
+    def get_aggregation_metric_suffix(self, aggregation: str) -> str:
+        """Overwrites base class with desired suffix"""
+        return f"patch-{self.features_patch_aggregation}-feat-rob-{aggregation}"
+
+    def get_over_targets_metric_prefix(self) -> str:
+        """Overwrites base class with desired prefix"""
+        return f"robustness-of-linear-model-over-{self.target_key}s/"

--- a/ahcore/metrics/linear_probing.py
+++ b/ahcore/metrics/linear_probing.py
@@ -1,0 +1,40 @@
+"""implementaion of linear probing as metric and loss"""
+
+import torch
+from sklearn import linear_model, metrics
+
+# from sklearn.model_selection import train_test_split
+from sklearn.model_selection import StratifiedShuffleSplit
+from torch import nn
+
+
+class LinearProbing(nn.Module):
+    """Module used for linear probing during training"""
+
+    def __init__(self, model_name, test_size: float = 0.3, scoring="accuracy", **kwargs) -> None:
+        """
+        Params:
+            model_name: name of the linear model to be used
+            test_size: portion of data to use as test data
+            scoring: string specifying the scoring to be performed (e.g. accuracy, auc),
+                default accuracy
+            kwargs: kwargs to be passed to the linear model
+        """
+        super().__init__()
+        self.test_size = test_size
+        self.clf = getattr(linear_model, model_name)(**kwargs)
+        self.scorer = metrics.get_scorer(scoring)
+
+    def forward(self, input: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
+        """runs the linear probing"""
+        input_np, target_np = input.detach().cpu().numpy(), target.detach().cpu().numpy()
+        # ensure stratified splitting of target classes
+        splitter = StratifiedShuffleSplit(n_splits=1, test_size=self.test_size)
+        indices_train, indices_test = next(splitter.split(input_np, target_np))
+        x_train, y_train = input_np[indices_train], target_np[indices_train]
+        x_test, y_test = input_np[indices_test], target_np[indices_test]
+        try:
+            self.clf.fit(x_train, y_train)
+        except ValueError:  # data may only contain one class
+            return torch.tensor(0.0)
+        return torch.tensor(self.scorer(self.clf, x_test, y_test))

--- a/ahcore/metrics/metrics.py
+++ b/ahcore/metrics/metrics.py
@@ -12,7 +12,6 @@ import torch.nn.functional as F  # noqa
 from ahcore.exceptions import ConfigurationError
 from ahcore.utils.data import DataDescription
 
-
 class AhCoreMetric:
     def __init__(self, data_description: DataDescription) -> None:
         """Initialize the metric class"""

--- a/ahcore/models/attention_unet.py
+++ b/ahcore/models/attention_unet.py
@@ -1,73 +1,75 @@
-# encoding: utf-8
-"""Attention U-net model [1] for segmentation
-
-References
-----------
-[1] https://arxiv.org/abs/1804.03999
-"""
-from __future__ import annotations
+from typing import List
 
 import torch
-from torch import nn
+from torch import nn as nn
 
 
 class ConvBlock(nn.Module):
-    def __init__(self, num_input_ch: int, num_output_ch: int, dropout_prob: float):
-        super().__init__()
+    """ConvBlock"""
+
+    def __init__(self, ch_in: int, ch_out: int, dropout_rate: float):
+        super(ConvBlock, self).__init__()
         self.conv = nn.Sequential(
-            nn.Conv2d(num_input_ch, num_output_ch, kernel_size=(3, 3), padding=1),
-            nn.Dropout2d(dropout_prob),
-            nn.BatchNorm2d(num_output_ch),
+            nn.Conv2d(ch_in, ch_out, kernel_size=(3, 3), padding=1),
+            nn.Dropout2d(dropout_rate),
+            nn.BatchNorm2d(ch_out),
             nn.ReLU(),
-            nn.Conv2d(num_output_ch, num_output_ch, kernel_size=(3, 3), padding=1),
-            nn.Dropout2d(dropout_prob),
-            nn.BatchNorm2d(num_output_ch),
+            nn.Conv2d(ch_out, ch_out, kernel_size=(3, 3), padding=1),
+            nn.Dropout2d(dropout_rate),
+            nn.BatchNorm2d(ch_out),
             nn.ReLU(),
         )
 
     def forward(self, x) -> torch.Tensor:
+        """forward"""
         x = self.conv(x)
         return x
 
 
 class DeconvBlock(nn.Module):
-    def __init__(self, num_input_ch: int, num_output_ch: int, dropout_prob: float):
-        super().__init__()
+    """DeconvBlock"""
+
+    def __init__(self, ch_in: int, ch_out: int, dropout_rate: float):
+        super(DeconvBlock, self).__init__()
         self.deconv = nn.Sequential(
-            (nn.ConvTranspose2d(num_input_ch, num_output_ch, kernel_size=(2, 2), stride=(2, 2))),
-            nn.Dropout2d(dropout_prob),
+            (nn.ConvTranspose2d(ch_in, ch_out, kernel_size=(2, 2), stride=(2, 2))),
+            nn.Dropout2d(dropout_rate),
         )
 
     def forward(self, x) -> torch.Tensor:
+        """forward"""
         x = self.deconv(x)
         return x
 
 
 class AttentionBlock(nn.Module):
-    def __init__(self, num_input_ch: int, ch_skip: int, num_output_ch: int, dropout_prob: float):
-        super().__init__()
+    """AttentionBlock"""
+
+    def __init__(self, ch_in: int, ch_skip: int, ch_out: int, dropout_rate: float):
+        super(AttentionBlock, self).__init__()
         self.W_skip = nn.Sequential(
-            nn.Conv2d(ch_skip, num_output_ch, kernel_size=(1, 1), padding=0),
-            nn.Dropout2d(dropout_prob),
-            nn.BatchNorm2d(num_output_ch),
+            nn.Conv2d(ch_skip, ch_out, kernel_size=(1, 1), padding=0),
+            nn.Dropout2d(dropout_rate),
+            nn.BatchNorm2d(ch_out),
         )
 
         self.W_in = nn.Sequential(
-            nn.Conv2d(num_input_ch, num_output_ch, kernel_size=(1, 1), padding=0),
-            nn.Dropout2d(dropout_prob),
-            nn.BatchNorm2d(num_output_ch),
+            nn.Conv2d(ch_in, ch_out, kernel_size=(1, 1), padding=0),
+            nn.Dropout2d(dropout_rate),
+            nn.BatchNorm2d(ch_out),
         )
 
         self.relu = nn.ReLU()
 
         self.psi = nn.Sequential(
-            nn.Conv2d(num_output_ch, 1, kernel_size=(1, 1), padding=0),
-            nn.Dropout2d(dropout_prob),
+            nn.Conv2d(ch_out, 1, kernel_size=(1, 1), padding=0),
+            nn.Dropout2d(dropout_rate),
             nn.BatchNorm2d(1),
             nn.Sigmoid(),
         )
 
     def forward(self, x: torch.Tensor, skip: torch.Tensor) -> torch.Tensor:
+        """forward"""
         g = self.W_skip(skip)
         x = self.W_in(x)
         psi = self.relu(g + x)
@@ -76,142 +78,113 @@ class AttentionBlock(nn.Module):
 
 
 class Encoder(nn.Module):
-    def __init__(self, num_input_ch: int, num_initial_filters: int, dropout_prob: float, depth: int = 4):
+    """Encoder"""
+
+    def __init__(self, inp_channel: int, kernel_multiplier: int, dropout_rate: float, depth: int):
         super().__init__()
-        self._num_input_ch = num_input_ch
-        self._num_initial_filters = num_initial_filters
-        self._dropout_rate = dropout_prob
-        self._depth = depth
+        self.depth = depth
+        for i in range(self.depth + 1):
+            ch_in = inp_channel if i == 0 else ch_out
+            ch_out = kernel_multiplier * (2 ** (i + 3))
+            setattr(self, f"conv_{i}", ConvBlock(ch_in, ch_out, dropout_rate))
+            if i < self.depth:
+                setattr(self, f"pool_{i}", nn.MaxPool2d(kernel_size=(2, 2), stride=(2, 2)))
 
-        first_block = ConvBlock(
-            num_input_ch=self._num_input_ch, num_output_ch=self._num_initial_filters, dropout_prob=self._dropout_rate
-        )
-
-        self.max_pool = nn.MaxPool2d(kernel_size=2, stride=2)
-        self.conv_blocks = nn.ModuleList([first_block])
-
-        for idx in range(0, self._depth):
-            num_channels = self._num_initial_filters * 2**idx
-            self.conv_blocks.append(
-                ConvBlock(num_input_ch=num_channels, num_output_ch=num_channels * 2, dropout_prob=self._dropout_rate)
-            )
-
-    def forward(self, x) -> list[torch.Tensor]:
-        output = []
-        x_in = self.conv_blocks[0](x)
-        output.append(x_in)
-        for idx in range(0, self._depth):
-            x_out = self.max_pool(x_in)
-            x_in = self.conv_blocks[idx + 1](x_out)
-            output.append(x_in)
-
-        return output
+    def forward(self, x) -> List:
+        """forward"""
+        enc_features = []
+        for i in range(self.depth):
+            x = getattr(self, f"conv_{i}")(x)
+            enc_features.append(x)
+            x = getattr(self, f"pool_{i}")(x)
+        x = getattr(self, f"conv_{self.depth}")(x)
+        enc_features.append(x)
+        return enc_features
 
 
 class Decoder(nn.Module):
-    def __init__(self, num_initial_filters: int, dropout_prob: float, depth: int = 4):
+    """Decoder"""
+
+    def __init__(
+        self,
+        kernel_multiplier: int,
+        dropout_rate: float,
+        num_classes: int,
+        depth: int,
+    ):
         super().__init__()
-
         self.depth = depth
-
-        self.conv_layers = nn.ModuleList()
-        self.deconv_layers = nn.ModuleList()
-        self.attention_layers = nn.ModuleList()
-
-        for divisor in range(0, depth):
-            convolution_channels = num_initial_filters * 16 // 2**divisor
-            self.conv_layers.append(
-                ConvBlock(
-                    num_input_ch=convolution_channels,
-                    num_output_ch=convolution_channels // 2,
-                    dropout_prob=dropout_prob,
-                )
+        for i in range(self.depth):
+            ch_in = kernel_multiplier * (2 ** (self.depth - (i + 1) + 4))
+            ch_out = kernel_multiplier * (2 ** (self.depth - (i + 1) + 3))
+            next_lvl_ch = kernel_multiplier * (2 ** (self.depth - (i + 1) + 2))
+            setattr(self, f"up_sample_{i}", DeconvBlock(ch_in, ch_out, dropout_rate))
+            setattr(
+                self,
+                f"attention_{i}",
+                AttentionBlock(ch_in=ch_out, ch_skip=ch_out, ch_out=next_lvl_ch, dropout_rate=dropout_rate),
             )
-            self.deconv_layers.append(
-                DeconvBlock(
-                    num_input_ch=convolution_channels,
-                    num_output_ch=convolution_channels // 2,
-                    dropout_prob=dropout_prob,
-                )
-            )
+            setattr(self, f"dec_conv_{i}", ConvBlock(ch_in=ch_in, ch_out=ch_out, dropout_rate=dropout_rate))
 
-            attention_channels = num_initial_filters * 8 // 2**divisor
-            self.attention_layers.append(
-                AttentionBlock(
-                    num_input_ch=attention_channels,
-                    ch_skip=attention_channels,
-                    num_output_ch=attention_channels // 2,
-                    dropout_prob=dropout_prob,
-                )
-            )
+        self.output_layer = OutputLayer(kernel_multiplier * 8, num_classes)
 
-    def forward(self, skip_output) -> torch.Tensor:
-        d5 = self.deconv_layers[0](skip_output[-1])
-        s4 = self.attention_layers[0](x=d5, skip=skip_output[-2])
-        d5 = torch.cat((s4, d5), dim=1)
-        d5 = self.conv_layers[0](d5)
-
-        d4 = self.deconv_layers[1](d5)
-        s3 = self.attention_layers[1](x=d4, skip=skip_output[-3])
-        d4 = torch.cat((s3, d4), dim=1)
-        d4 = self.conv_layers[1](d4)
-
-        d3 = self.deconv_layers[2](d4)
-        s2 = self.attention_layers[2](x=d3, skip=skip_output[-4])
-        d3 = torch.cat((s2, d3), dim=1)
-        d3 = self.conv_layers[2](d3)
-
-        d2 = self.deconv_layers[3](d3)
-        s1 = self.attention_layers[3](x=d2, skip=skip_output[-5])
-        d2 = torch.cat((s1, d2), dim=1)
-        d2 = self.conv_layers[3](d2)
-
-        return d2
+    def forward(self, encoder_features: List) -> torch.Tensor:
+        """forward"""
+        dec_features = []
+        for i in range(self.depth):
+            dec_feature = getattr(self, f"up_sample_{i}")(encoder_features[-i - 1])
+            attention_maps = getattr(self, f"attention_{i}")(dec_feature, encoder_features[-i - 2])
+            dec_feature = torch.cat([dec_feature, attention_maps], dim=1)
+            dec_feature = getattr(self, f"dec_conv_{i}")(dec_feature)
+            dec_features.append(dec_feature)
+        return self.output_layer(dec_features[-1])
 
 
 class OutputLayer(nn.Module):
-    def __init__(self, num_initial_filters: int, num_output_ch: int):
+    """OutputLayer"""
+
+    def __init__(self, inp_ch: int, num_classes: int):
         super().__init__()
-        self.output = nn.Sequential(
+        layers = [
             nn.Conv2d(
-                in_channels=num_initial_filters,
-                out_channels=num_output_ch,
+                in_channels=inp_ch,
+                out_channels=num_classes,
                 kernel_size=(1, 1),
                 stride=(1, 1),
                 padding=0,
-            ),
-        )
+            )
+        ]
+        self.output_layer = nn.Sequential(*layers)
 
     def __call__(self, x):
-        output_layer = self.output(x)
-        return output_layer
+        return self.output_layer(x)
 
 
 class AttentionUnet(nn.Module):
-    def __init__(
-        self,
-        num_input_ch: int,
-        num_classes: int,
-        num_initial_filters: int,
-        depth: int,
-        dropout_prob: float,
-    ):
-        super().__init__()
-        self.encoder = Encoder(
-            num_input_ch=num_input_ch,
-            num_initial_filters=num_initial_filters,
-            dropout_prob=dropout_prob,
-            depth=depth,
-        )
-        self.decoder = Decoder(num_initial_filters=num_initial_filters, dropout_prob=dropout_prob, depth=depth)
-        self.output_layer = OutputLayer(
-            num_initial_filters=num_initial_filters,
-            num_output_ch=num_classes,
-        )
-        self.num_classes = num_classes
+    """AttentionUnet"""
 
-    def forward(self, x) -> torch.Tensor:
-        skip_features = self.encoder(x)
-        decoder_output = self.decoder(skip_features)
-        output = self.output_layer(decoder_output)
-        return output
+    def __init__(self, inp_channel: int, kernel_multiplier: int, depth: int, dropout_rate: float, num_classes: int, return_features: bool = False):
+        super().__init__()
+        self.return_features = return_features
+        self.encoder = Encoder(inp_channel, kernel_multiplier, dropout_rate, depth=depth)
+        self.decoder = Decoder(kernel_multiplier, dropout_rate, num_classes, depth=depth)
+
+    def forward(self, x) -> torch.Tensor | tuple[torch.Tensor, tuple[torch.Tensor]]:
+        """
+        Args:
+            x: (batch_size, inp_channel, height, width)
+        Returns:
+            output: (batch_size, num_classes, height, width)
+            or
+            output: (batch_size, num_classes, height, width)
+            features: List[torch.Tensor]
+        """
+        encoder_features = self.encoder(x)
+        segmentation_maps = self.decoder(encoder_features)
+        if self.return_features:
+            deep_features = ()
+            for i in range(self.encoder.depth):
+                deep_features = deep_features + (encoder_features[-i - 1].clone(),)
+            return segmentation_maps, deep_features
+        else:
+            return segmentation_maps

--- a/ahcore/trackers.py
+++ b/ahcore/trackers.py
@@ -17,7 +17,7 @@ from dlup.writers import TiffCompression, TifffileImageWriter
 from torch import Tensor
 
 from ahcore.utils.io import get_logger
-
+from dlup._image import Resampling
 logger = get_logger(__name__)
 
 
@@ -41,11 +41,14 @@ class TiffWriter(Tracker):
         pyramid: bool = False,
         compression: str | None = "jpeg",
         quality: int | None = 100,
+        is_mask: bool = True,
     ):
         self.save_dir = save_dir
         self.pyramid = pyramid
         self.compression = TiffCompression(compression)
         self.quality = quality
+
+        self._interpolator = Resampling.NEAREST if is_mask else None
 
     @staticmethod
     def create_pred_iterator(predictions: list[list[Tensor]]):
@@ -66,6 +69,7 @@ class TiffWriter(Tracker):
             pyramid=self.pyramid,
             compression=self.compression,
             quality=self.quality,
+            interpolator=self._interpolator,
         )
 
         pred_iter = self.create_pred_iterator(predictions)

--- a/ahcore/transforms/augmentations.py
+++ b/ahcore/transforms/augmentations.py
@@ -200,9 +200,8 @@ class AugmentationFactory(nn.Module):
 
     def forward(self, sample):
         output_data = [sample[key] for key in self._transformable_keys if key in sample]
-
         if self._initial_transforms:
-            kwargs = {"data_keys": self._data_keys}
+            kwargs = {"data_keys": self._data_keys, "filenames": sample["path"]}
             for transform in self._initial_transforms:
                 output_data = transform(*output_data, **kwargs)
 

--- a/ahcore/transforms/augmentations.py
+++ b/ahcore/transforms/augmentations.py
@@ -68,8 +68,9 @@ class MeanStdNormalizer(nn.Module):
         else:
             self._std = nn.Parameter(torch.Tensor(std), requires_grad=False)
 
-    def forward(self, *args: torch.Tensor, data_keys: list[str | int | DataKey]):
+    def forward(self, *args: torch.Tensor, **kwargs):
         output = []
+        data_keys = kwargs["data_keys"]
         for sample, data_key in zip(args, data_keys):
             if data_key in [DataKey.INPUT, 0, "INPUT"]:
                 sample = sample / 255.0
@@ -100,7 +101,7 @@ class CenterCrop(nn.Module):
             size=_size, align_corners=True, p=1.0, keepdim=False, cropping_mode="slice", return_transform=None
         )
 
-    def forward(self, *sample: torch.Tensor, data_keys: list[str | int | DataKey] = None):
+    def forward(self, *sample: torch.Tensor, data_keys: list[str | int | DataKey] = None, **kwargs):
         output = [self._cropper(item) for item in sample]
 
         if len(output) == 1:
@@ -201,8 +202,9 @@ class AugmentationFactory(nn.Module):
         output_data = [sample[key] for key in self._transformable_keys if key in sample]
 
         if self._initial_transforms:
+            kwargs = {"data_keys": self._data_keys}
             for transform in self._initial_transforms:
-                output_data = transform(*output_data, data_keys=self._data_keys)
+                output_data = transform(*output_data, **kwargs)
 
         if isinstance(output_data, torch.Tensor):
             output_data = [output_data]

--- a/ahcore/transforms/augmentations.py
+++ b/ahcore/transforms/augmentations.py
@@ -98,7 +98,7 @@ class CenterCrop(nn.Module):
             _size = tuple(size)
 
         self._cropper = K.CenterCrop(
-            size=_size, align_corners=True, p=1.0, keepdim=False, cropping_mode="slice", return_transform=None
+            size=_size, align_corners=True, p=1.0, keepdim=False, cropping_mode="slice"
         )
 
     def forward(self, *sample: torch.Tensor, data_keys: list[str | int | DataKey] = None, **kwargs):

--- a/ahcore/transforms/image_normalization.py
+++ b/ahcore/transforms/image_normalization.py
@@ -173,80 +173,6 @@ class MacenkoNormalizer(nn.Module):
         self._he_reference = self.HE_REFERENCE
         self._max_con_reference = self.MAX_CON_REFERENCE
 
-    def convert_rgb_to_optical_density(self, image_tensor: torch.Tensor) -> tuple[torch.Tensor, list[torch.Tensor]]:
-        """
-        This function converts an RGB image to optical density values following the Beer-Lambert's law.
-        Parameters
-        ----------
-        image_tensor: torch.Tensor
-            RGB image tensor, shape (B, 3, H, W)
-        Returns
-        -------
-        optical_density: torch.Tensor
-            Optical density of the image tensor, shape (B, H*W, 3)
-        optical_density_hat: list[torch.Tensor]
-            Optical density of the image tensor, shape (B, num_foreground_pixels, 3)
-        """
-        image_tensor = image_tensor.permute(0, 2, 3, 1).contiguous()
-        num_tiles, height, width, channels = image_tensor.shape
-        # calculate optical density
-        optical_density = -torch.log((image_tensor.to(torch.float64) + 1) / self._transmitted_intensity)
-        # remove transparent pixels
-        mask = optical_density.min(dim=-1).values > self._beta
-        optical_density_hat = [optical_density[i][mask[i]] for i in range(num_tiles)]
-        return optical_density, optical_density_hat
-
-    def convert_optical_density_to_rgb(self, od_tensor: torch.Tensor) -> torch.Tensor:
-        """
-        Converts optical density values to RGB
-        Parameters
-        ----------
-        od_tensor: torch.Tensor
-            Optical density of the image.
-        Returns
-        -------
-        rgb_tensor: torch.Tensor
-            RGB image.
-        """
-        projection_to_reference_stains = -self._he_reference.to(od_tensor) @ od_tensor
-        optical_density_to_rgb = torch.exp(projection_to_reference_stains)
-        normalised_image_tensor = optical_density_to_rgb * self._transmitted_intensity
-        normalised_image_tensor[normalised_image_tensor > 255.] = 255.
-        return normalised_image_tensor
-
-    def _find_he_components(self, optical_density_hat: torch.Tensor, eigvecs: torch.Tensor) -> torch.Tensor:
-        """
-        This function -
-        1. Computes the H&E staining vectors by projecting the OD values of the image pixels on the plane
-        spanned by the eigenvectors corresponding to their two largest eigenvalues.
-        2. Normalizes the staining vectors to unit length.
-        3. Calculates the angle between each of the projected points and the first principal direction.
-        Parameters:
-        ----------
-        optical_density_hat: torch.Tensor
-            Optical density of the image
-        eigvecs: torch.Tensor
-            Eigenvectors of the covariance matrix
-        Returns:
-        -------
-        he_components: torch.Tensor
-            The H&E staining vectors
-        """
-        t_hat = torch.matmul(optical_density_hat, eigvecs)
-        phi = torch.atan2(t_hat[:, 1], t_hat[:, 0])
-        min_phi = percentile(phi, self._alpha)
-        max_phi = percentile(phi, 100 - self._alpha)
-
-        v_min = torch.matmul(eigvecs, torch.stack((torch.cos(min_phi), torch.sin(min_phi)))).unsqueeze(1)
-        v_max = torch.matmul(eigvecs, torch.stack((torch.cos(max_phi), torch.sin(max_phi)))).unsqueeze(1)
-
-        # a heuristic to make the vector corresponding to hematoxylin first and the one corresponding to eosin second
-        he_vector = torch.where(
-            v_min[0] > v_max[0], torch.cat((v_min, v_max), dim=1), torch.cat((v_max, v_min), dim=1)
-        )
-
-        return he_vector
-
     def __compute_matrices(
             self, image_tensor: torch.Tensor, staining_parameters: dict[str: torch.Tensor]
     ) -> tuple(torch.Tensor, torch.Tensor):
@@ -270,51 +196,6 @@ class MacenkoNormalizer(nn.Module):
             he_concentrations, max_concentrations = _compute_concentrations(he, od_tensor)
             batch_con_vecs.append(he_concentrations)
         return torch.stack(batch_con_vecs, dim=0)
-
-    def fit(self, wsi: torch.Tensor, wsi_name: str, dump_to_folder: Optional[Path] = None) -> dict[str: torch.Tensor]:
-        """
-        Compress a WSI to a single matrix of eigenvectors and return staining parameters.
-        Parameters:
-        ----------
-        wsi: torch.tensor
-            A tensor containing a whole slide image of shape (1, channels, height, width)
-        name: Path
-            Path to the WSI file
-        Returns:
-        -------
-        staining_parameters: dict[str: torch.Tensor, str: torch.Tensor]
-            The eigenvectors of the optical density values of the pixels in the image.
-        Note:
-            Dimensions of HE vector are: (3 x 2)
-            Dimensions of max cancentration vector are: (2)
-            Dimensions of wsi_eigenvectors are: (3 x 2)
-        """
-        logger.info("Fitting stain matrix for WSI: %s", wsi_name)
-        optical_density, optical_density_hat = self.convert_rgb_to_optical_density(wsi)
-        optical_density = optical_density.squeeze(0).view(-1, 3)
-        wsi_eigenvectors = _compute_eigenvecs(optical_density_hat[0])
-        wsi_level_he = self._find_he_components(optical_density_hat[0], wsi_eigenvectors)
-        wsi_level_concentrations, wsi_level_max_concentrations = _compute_concentrations(wsi_level_he, optical_density)
-        staining_parameters = {
-            "wsi_name": wsi_name,
-            "wsi_staining_vectors": wsi_level_he.unsqueeze(0),
-            "max_wsi_concentration": wsi_level_max_concentrations.unsqueeze(0).unsqueeze(0),
-        }
-        if dump_to_folder:
-            dump_staining_parameters(staining_parameters, dump_to_folder)
-        return staining_parameters
-
-    def set(self, target_image: torch.Tensor) -> None:
-        """
-        Set the reference image for the stain normaliser.
-        Parameters:
-        ----------
-        target_image: torch.Tensor
-            The reference image for the stain normaliser.
-        """
-        staining_parameters = self.fit(wsi=target_image, wsi_name="target image")
-        self._he_reference = staining_parameters["wsi_staining_vectors"]
-        self._max_con_reference = staining_parameters["max_wsi_concentration"]
 
     def __normalize_concentrations(
             self, concentrations: torch.Tensor, maximum_concentration: torch.tensor
@@ -391,6 +272,125 @@ class MacenkoNormalizer(nn.Module):
         h_stain = _handle_stain_tensors(h_stain, image_tensor.shape)
         e_stain = _handle_stain_tensors(e_stain, image_tensor.shape)
         return h_stain, e_stain
+
+    def _find_he_components(self, optical_density_hat: torch.Tensor, eigvecs: torch.Tensor) -> torch.Tensor:
+        """
+        This function -
+        1. Computes the H&E staining vectors by projecting the OD values of the image pixels on the plane
+        spanned by the eigenvectors corresponding to their two largest eigenvalues.
+        2. Normalizes the staining vectors to unit length.
+        3. Calculates the angle between each of the projected points and the first principal direction.
+        Parameters:
+        ----------
+        optical_density_hat: torch.Tensor
+            Optical density of the image
+        eigvecs: torch.Tensor
+            Eigenvectors of the covariance matrix
+        Returns:
+        -------
+        he_components: torch.Tensor
+            The H&E staining vectors
+        """
+        t_hat = torch.matmul(optical_density_hat, eigvecs)
+        phi = torch.atan2(t_hat[:, 1], t_hat[:, 0])
+        min_phi = percentile(phi, self._alpha)
+        max_phi = percentile(phi, 100 - self._alpha)
+
+        v_min = torch.matmul(eigvecs, torch.stack((torch.cos(min_phi), torch.sin(min_phi)))).unsqueeze(1)
+        v_max = torch.matmul(eigvecs, torch.stack((torch.cos(max_phi), torch.sin(max_phi)))).unsqueeze(1)
+
+        # a heuristic to make the vector corresponding to hematoxylin first and the one corresponding to eosin second
+        he_vector = torch.where(
+            v_min[0] > v_max[0], torch.cat((v_min, v_max), dim=1), torch.cat((v_max, v_min), dim=1)
+        )
+
+        return he_vector
+
+    def convert_rgb_to_optical_density(self, image_tensor: torch.Tensor) -> tuple[torch.Tensor, list[torch.Tensor]]:
+        """
+        This function converts an RGB image to optical density values following the Beer-Lambert's law.
+        Parameters
+        ----------
+        image_tensor: torch.Tensor
+            RGB image tensor, shape (B, 3, H, W)
+        Returns
+        -------
+        optical_density: torch.Tensor
+            Optical density of the image tensor, shape (B, H*W, 3)
+        optical_density_hat: list[torch.Tensor]
+            Optical density of the image tensor, shape (B, num_foreground_pixels, 3)
+        """
+        image_tensor = image_tensor.permute(0, 2, 3, 1).contiguous()
+        num_tiles, height, width, channels = image_tensor.shape
+        # calculate optical density
+        optical_density = -torch.log((image_tensor.to(torch.float64) + 1) / self._transmitted_intensity)
+        # remove transparent pixels
+        mask = optical_density.min(dim=-1).values > self._beta
+        optical_density_hat = [optical_density[i][mask[i]] for i in range(num_tiles)]
+        return optical_density, optical_density_hat
+
+    def convert_optical_density_to_rgb(self, od_tensor: torch.Tensor) -> torch.Tensor:
+        """
+        Converts optical density values to RGB
+        Parameters
+        ----------
+        od_tensor: torch.Tensor
+            Optical density of the image.
+        Returns
+        -------
+        rgb_tensor: torch.Tensor
+            RGB image.
+        """
+        projection_to_reference_stains = -self._he_reference.to(od_tensor) @ od_tensor
+        optical_density_to_rgb = torch.exp(projection_to_reference_stains)
+        normalised_image_tensor = optical_density_to_rgb * self._transmitted_intensity
+        normalised_image_tensor[normalised_image_tensor > 255.] = 255.
+        return normalised_image_tensor
+
+    def fit(self, wsi: torch.Tensor, wsi_name: str, dump_to_folder: Optional[Path] = None) -> dict[str: torch.Tensor]:
+        """
+        Compress a WSI to a single matrix of eigenvectors and return staining parameters.
+        Parameters:
+        ----------
+        wsi: torch.tensor
+            A tensor containing a whole slide image of shape (1, channels, height, width)
+        name: Path
+            Path to the WSI file
+        Returns:
+        -------
+        staining_parameters: dict[str: torch.Tensor, str: torch.Tensor]
+            The eigenvectors of the optical density values of the pixels in the image.
+        Note:
+            Dimensions of HE vector are: (3 x 2)
+            Dimensions of max cancentration vector are: (2)
+            Dimensions of wsi_eigenvectors are: (3 x 2)
+        """
+        logger.info("Fitting stain matrix for WSI: %s", wsi_name)
+        optical_density, optical_density_hat = self.convert_rgb_to_optical_density(wsi)
+        optical_density = optical_density.squeeze(0).view(-1, 3)
+        wsi_eigenvectors = _compute_eigenvecs(optical_density_hat[0])
+        wsi_level_he = self._find_he_components(optical_density_hat[0], wsi_eigenvectors)
+        wsi_level_concentrations, wsi_level_max_concentrations = _compute_concentrations(wsi_level_he, optical_density)
+        staining_parameters = {
+            "wsi_name": wsi_name,
+            "wsi_staining_vectors": wsi_level_he.unsqueeze(0),
+            "max_wsi_concentration": wsi_level_max_concentrations.unsqueeze(0).unsqueeze(0),
+        }
+        if dump_to_folder:
+            dump_staining_parameters(staining_parameters, dump_to_folder)
+        return staining_parameters
+
+    def set(self, target_image: torch.Tensor) -> None:
+        """
+        Set the reference image for the stain normaliser.
+        Parameters:
+        ----------
+        target_image: torch.Tensor
+            The reference image for the stain normaliser.
+        """
+        staining_parameters = self.fit(wsi=target_image, wsi_name="target image")
+        self._he_reference = staining_parameters["wsi_staining_vectors"]
+        self._max_con_reference = staining_parameters["max_wsi_concentration"]
 
     def forward(self, *args: tuple[torch.Tensor], **kwargs) -> list[torch.Tensor]:
         output = []

--- a/ahcore/transforms/image_normalization.py
+++ b/ahcore/transforms/image_normalization.py
@@ -1,12 +1,11 @@
 # encoding: utf-8
 """
-Image normalization functions
+Histopathology stain specific image normalization functions
 # TODO: Support `return_stains = True` for MacenkoNormalization()
-# TODO: Use torch.linalg.lstsq to solve the linear system of equations in MacenkoNormalization().
 """
 from __future__ import annotations
 
-from typing import Optional, Iterable
+from typing import Optional
 
 import torch
 import torch.nn as nn
@@ -22,6 +21,30 @@ def _transpose_channels(tensor: torch.Tensor) -> torch.Tensor:
     return tensor
 
 
+def _compute_concentrations(
+    he_vector: torch.Tensor, optical_density: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """
+    This function computes the concentrations of the individual stains.
+    Parameters
+    ----------
+    he_vector : torch.Tensor
+        The H&E staining vectors
+    optical_density: torch.Tensor
+        Optical density of the image
+
+    Returns
+    -------
+    he_concentrations: torch.Tensor
+        Concentrations of the individual stains
+    max_concentrations: torch.Tensor
+        Maximum concentrations of the individual stains
+    """
+    he_concentrations = he_vector.pinverse() @ optical_density.T
+    max_concentration = torch.stack([percentile(he_concentrations[0, :], 99), percentile(he_concentrations[1, :], 99)])
+    return he_concentrations, max_concentration
+
+
 def covariance_matrix(tensor: torch.Tensor) -> torch.Tensor:
     """
     https://en.wikipedia.org/wiki/Covariance_matrix
@@ -29,6 +52,25 @@ def covariance_matrix(tensor: torch.Tensor) -> torch.Tensor:
     e_x = tensor.mean(dim=1)
     tensor = tensor - e_x[:, None]
     return torch.mm(tensor, tensor.T) / (tensor.size(1) - 1)
+
+
+def _compute_eigenvecs(optical_density_hat: torch.Tensor) -> torch.Tensor:
+    """
+    This function computes the eigenvectors of the covariance matrix of the optical density values.
+    Parameters:
+    ----------
+    optical_density_hat: list[torch.Tensor]
+        Optical density of the image
+
+    Returns:
+    -------
+    eigvecs: torch.Tensor
+        Eigenvectors of the covariance matrix
+    """
+    _, eigvecs = torch.linalg.eigh(covariance_matrix(optical_density_hat.T), UPLO="U")
+    # choose the first two eigenvectors corresponding to the two largest eigenvalues.
+    eigvecs = eigvecs[:, [1, 2]]
+    return eigvecs
 
 
 def percentile(tensor: torch.Tensor, value: float) -> torch.Tensor:
@@ -69,12 +111,12 @@ class MacenkoNormalizer(nn.Module):
     MAX_CON_REFERENCE = torch.Tensor([1.3484, 1.0886])
 
     def __init__(
-            self,
-            alpha: float = 1.0,
-            beta: float = 0.15,
-            transmitted_intensity: int = 240,
-            return_stains: bool = False,
-            probability: float = 1.0,
+        self,
+        alpha: float = 1.0,
+        beta: float = 0.15,
+        transmitted_intensity: int = 240,
+        return_stains: bool = False,
+        probability: float = 1.0,
     ):
         """
         Normalize staining appearence of hematoxylin & eosin stained images. Based on [1].
@@ -107,26 +149,60 @@ class MacenkoNormalizer(nn.Module):
         self._max_con_reference = self.MAX_CON_REFERENCE
 
     def convert_rgb_to_optical_density(self, image_tensor: torch.Tensor) -> tuple[torch.Tensor, list[torch.Tensor]]:
+        """
+        This function converts an RGB image to optical density values following the Beer-Lambert's law.
+        Parameters
+        ----------
+        image_tensor: torch.Tensor
+            RGB image tensor, shape (B, 3, H, W)
+
+        Returns
+        -------
+        optical_density: torch.Tensor
+            Optical density of the image tensor, shape (B, H*W, 3)
+
+        optical_density_hat: list[torch.Tensor]
+            Optical density of the image tensor, shape (B, num_foreground_pixels, 3)
+        """
         image_tensor = image_tensor.permute(0, 2, 3, 1)
+        num_tiles, height, width, channels = image_tensor.shape
         # calculate optical density
         optical_density = -torch.log(
-            (image_tensor.reshape(
-                (image_tensor.shape[0], -1, image_tensor.shape[-1])).float() + 1) / self._transmitted_intensity
+            (image_tensor.reshape((num_tiles, -1, channels)).float() + 1) / self._transmitted_intensity
         )
         # remove transparent pixels
         optical_density_hat = [sample[~torch.any(sample < self._beta, dim=1)] for sample in optical_density]
+        # Remove lone pixels (i.e. if non-transparent pixels in a tile do not exceed one-fifth of the tile width)
+        # This should be done to avoid ill-conditioned covariance matrices in downstream processing.
+        optical_density_hat = [
+            tile_pixels for tile_pixels in optical_density_hat if tile_pixels.shape[0] > (height / 5)
+        ]
         return optical_density, optical_density_hat
 
     def convert_optical_density_to_rgb(self, od_tensor: torch.Tensor) -> torch.Tensor:
+        """
+        Converts optical density values to RGB
+
+        Parameters
+        ----------
+        od_tensor: torch.Tensor
+            Optical density of the image.
+
+        Returns
+        -------
+        rgb_tensor: torch.Tensor
+            RGB image.
+        """
         normalised_image_tensor = []
         for norm_conc in od_tensor:
             normalised_image_tensor.append(
-                self._transmitted_intensity * torch.exp(-self._he_reference.to(norm_conc) @ norm_conc))
+                self._transmitted_intensity * torch.exp(-self._he_reference.to(norm_conc) @ norm_conc)
+            )
         normalised_image_tensor = torch.stack(normalised_image_tensor, dim=0)
         normalised_image_tensor[normalised_image_tensor > 255] = 255
         return normalised_image_tensor
 
-    def find_he_components(self, optical_density_hat: torch.Tensor, eigvecs: torch.Tensor) -> torch.Tensor:
+    def _find_he_components(self, optical_density_hat: torch.Tensor, eigvecs: torch.Tensor) -> torch.Tensor:
         """
         This function -
         1. Computes the H&E staining vectors by projecting the OD values of the image pixels on the plane
@@ -159,106 +235,76 @@ class MacenkoNormalizer(nn.Module):
 
         return he_vector
 
-    def __compute_matrices(self, image_tensor: torch.Tensor, eigenvectors: Optional[torch.Tensor | None] = None) -> \
-            tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    def __compute_matrices(
+        self, image_tensor: torch.Tensor, staining_parameters: Optional[dict[str : torch.Tensor] | None] = None
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         """
         Compute the H&E staining vectors and their concentration values for every pixel in the image tensor.
         """
         batch_he_vecs = []
         batch_max_con = []
         batch_con_vecs = []
+        wsi_eigenvectors = staining_parameters["wsi_eigenvectors"] if staining_parameters is not None else None
+        wsi_staining_vectors = staining_parameters["wsi_staining_vectors"] if staining_parameters is not None else None
         # Convert RGB values in the image to optical density values following the Beer-Lambert's law.
+        # Note - The dependence of staining and their concentrations are linear in OD space.
         optical_density, optical_density_hat = self.convert_rgb_to_optical_density(image_tensor)
-        # For every sample in the batch, calculate the eigenvectors of optical density matrix thresholded to remove transparent pixels.
+        # For tile in the optical density (OD) vector:
+        #  Step 1. calculate the eigenvectors of thresholded OD vector (optical_density_hat).
+        #  Step 2. find the H&E staining vectors by projecting the OD vector on the plane spanned by the eigenvectors.
+        #  Step 3. calculate the concentration of the H&E staining vectors for each pixel in the OD vector.
+        #  Step 4. Also return the maximum concentration of the H&E staining within the tile.
         for i in range(len(optical_density_hat)):
-            if optical_density_hat[i].shape[0] <= image_tensor.shape[2]/10:
-                logger.info("No pixels remaining after thresholding. Returning original tile.")
-                batch_he_vecs.append(torch.zeros(3, 2))
-                batch_max_con.append(torch.zeros(2))
-                batch_con_vecs.append(torch.zeros(2, image_tensor.shape[2]*image_tensor.shape[3]))
-                continue
-            if eigenvectors is None:
-                _, eigvecs = torch.linalg.eigh(covariance_matrix(optical_density_hat[i].T), UPLO="U")
-                # choose the first two eigenvectors corresponding to the two largest eigenvalues.
-                eigvecs = eigvecs[:, [1, 2]]
-            else:
-                eigvecs = eigenvectors[i]
-            # Find the H&E staining vectors and their concentration values for every pixel in the image tensor.
-            # Note - The dependence of staining and their concentrations are linear in OD space
-            he = self.find_he_components(optical_density_hat[i], eigvecs)
-            # Calculate the concentrations of the H&E stains in each pixel.
-            # We do this by solving a linear system of equations. (In this case, the system is overdetermined).
-            # OD =   HE * C -> (1)
-            # where:
-            #   1. OD is the optical density of the pixels in the batch. The dimension is: (n x 3)
-            #   2. HE is the H&E staining vectors (3 x 2). The dimension is: (3 x 2)
-            #   3. C is the concentration of the H&E stains in each pixel. The dimension is: (2 x n)
-            # The solution to this system of equation is unique and is computed in the following way:
-            concentration = he.pinverse() @ optical_density[i].T
-            max_concentration = torch.stack([percentile(concentration[0, :], 99), percentile(concentration[1, :], 99)])
+            # Performing Step 1:
+            eigvecs = _compute_eigenvecs(optical_density_hat[i]) if wsi_eigenvectors is None else wsi_eigenvectors[i]
+            # Performing Step 2:
+            he = (
+                self._find_he_components(optical_density_hat[i], eigvecs)
+                if wsi_staining_vectors is None
+                else wsi_staining_vectors[i]
+            )
+            # Performing Step 3, 4:
+            #   Calculate the concentrations of the H&E stains in each pixel.
+            #   We do this by solving a linear system of equations. (In this case, the system is overdetermined).
+            #   OD =   HE * C -> (1)
+            #   where:
+            #       1. OD is the optical density of the pixels in the batch. The dimension is: (n x 3)
+            #       2. HE is the H&E staining vectors (3 x 2). The dimension is: (3 x 2)
+            #       3. C is the concentration of the H&E stains in each pixel. The dimension is: (2 x n)
+            he_concentrations, max_concentrations = _compute_concentrations(he, optical_density[i])
             batch_he_vecs.append(he)
-            batch_max_con.append(max_concentration)
-            batch_con_vecs.append(concentration)
+            batch_max_con.append(max_concentrations)
+            batch_con_vecs.append(he_concentrations)
         return torch.stack(batch_he_vecs, dim=0), torch.stack(batch_con_vecs, dim=0), torch.stack(batch_max_con, dim=0)
 
-    def fit(self, tile_iterator: Iterable, reduce: str = "resultant") -> torch.Tensor | list[torch.Tensor]:
+    def fit(self, wsi: torch.Tensor) -> dict[str : torch.Tensor]:
         """
-        Compress multiple tiles from a WSI to a single matrix of eigenvectors.
+        Compress a WSI to a single matrix of eigenvectors and return staining parameters.
 
         Parameters:
         ----------
-        tile_iterator: Iterable
-            An iterator that returns a set of tiles from a single WSI.
-
-        reduce: str
-            The method to reduce the eigenvectors from multiple tiles to a single matrix.
-            Options are:
-            1. "resultant" - The resultant eigenvectors from all the tiles. (default)
-            2. "mean" - The mean of the eigenvectors from all the tiles.
-            3. "raw" - The raw eigenvectors from all the tiles as a list of tensors.
+        wsi: torch.tensor
+            A tensor containing a whole slide image of shape (1, channels, height, width)
 
         Returns:
         -------
-        eigenvectors: torch.Tensor | list[torch.Tensor]
-            The eigenvectors of the covariance matrix of the optical density values of the pixels in the image.
+        staining_parameters: dict[str: torch.Tensor, str: torch.Tensor]
+            The eigenvectors of the optical density values of the pixels in the image.
         """
-        if not hasattr(self, '_eigenvectors'):
-            setattr(self, "_eigenvectors", [])
-        for tile in tile_iterator:
-            _, optical_density_hat = self.convert_rgb_to_optical_density(tile.unsqueeze(0))
-            if optical_density_hat[0].shape[0] <= tile.shape[2]/10:
-                logger.info("Skipping tile due to thresholding.")
-                tile_level_eigenvecs = torch.zeros(3, 2)
-                self._eigenvectors.append(tile_level_eigenvecs)
-                continue
-            _, _eigvecs = torch.linalg.eigh(covariance_matrix(optical_density_hat[0].T), UPLO="U")
-            # choose the first two eigenvectors corresponding to the two largest eigenvalues.
-            tile_level_eigenvecs = _eigvecs[:, [1, 2]]
-            self._eigenvectors.append(tile_level_eigenvecs)
-        if reduce == "mean":
-            return torch.mean(torch.stack(self._eigenvectors, dim=0), dim=0)
-        elif reduce == "raw":
-            return torch.stack(self._eigenvectors, dim=0)
-        else:
-            # Return the resultant of the eigenvectors
-            resultant = torch.stack(self._eigenvectors, dim=0).sum(dim=0)
-            # Normalise the resultant using l2 norm
-            resultant = resultant / torch.linalg.norm(resultant, dim=0)
-            return resultant
-
-    def clear(self) -> None:
-        """
-        Clear the eigenvectors from memory.
-        """
-        if hasattr(self, "_eigenvectors"):
-            delattr(self, "_eigenvectors")
-        else:
-            raise AttributeError("No eigenvectors to clear.")
+        optical_density, optical_density_hat = self.convert_rgb_to_optical_density(wsi)
+        wsi_eigenvectors = _compute_eigenvecs(optical_density_hat[0])
+        wsi_level_he = self._find_he_components(optical_density_hat[0], wsi_eigenvectors)
+        _, wsi_level_max_concentrations = _compute_concentrations(wsi_level_he, optical_density[0])
+        staining_parameters = {
+            "wsi_staining_vectors": wsi_level_he,
+            "wsi_eigenvectors": wsi_eigenvectors,
+            "max_wsi_concentration": wsi_level_max_concentrations,
+        }
+        return staining_parameters
 
     def set(self, target_image: torch.Tensor) -> None:
         """
         Set the reference image for the stain normaliser.
-
         Parameters:
         ----------
         target_image: torch.Tensor
@@ -269,8 +315,22 @@ class MacenkoNormalizer(nn.Module):
         self._max_con_reference = maximum_concentration
 
     def __normalize_concentrations(
-            self, concentrations: torch.Tensor, maximum_concentration: torch.Tensor
+        self, concentrations: torch.Tensor, maximum_concentration: torch.Tensor
     ) -> torch.Tensor:
+        """
+        Normalize the concentrations of the H&E stains in each pixel against the reference concentration.
+
+        Parameters
+        ----------
+        concentrations: torch.Tensor
+            The concentration of the H&E stains in each pixel.
+        maximum_concentration
+            The maximum concentration of the H&E stains in each pixel.
+        Returns
+        -------
+        normalized_concentrations: torch.Tensor
+            The normalized concentration of the H&E stains in each pixel.
+        """
         output = []
         for conc, max_conc in zip(concentrations, maximum_concentration):
             norm_conc = conc * (self._max_con_reference.to(max_conc) / max_conc).unsqueeze(-1)
@@ -278,8 +338,23 @@ class MacenkoNormalizer(nn.Module):
         return torch.stack(output, dim=0)
 
     def __create_normalized_images(
-            self, normalized_concentrations: torch.Tensor, image_tensor: torch.Tensor
+        self, normalized_concentrations: torch.Tensor, image_tensor: torch.Tensor
     ) -> torch.Tensor:
+        """
+        Create the normalized images from the normalized concentrations.
+
+        Parameters
+        ----------
+        normalized_concentrations: torch.Tensor
+            The normalized concentrations of the H&E stains in the image.
+        image_tensor: torch.Tensor
+            The image tensor to be normalized.
+
+        Returns
+        -------
+        normalized_images: torch.Tensor
+            The normalized images.
+        """
         batch, classes, height, width = image_tensor.shape
         # recreate the image using reference mixing matrix
         normalised_image_tensor = self.convert_optical_density_to_rgb(od_tensor=normalized_concentrations)
@@ -287,40 +362,77 @@ class MacenkoNormalizer(nn.Module):
         normalised_image_tensor = _transpose_channels(normalised_image_tensor)
         return normalised_image_tensor
 
-    # def __get_h_stain(self, normalized_concentrations: torch.Tensor, image_tensor: torch.Tensor) -> torch.Tensor:
-    #     batch, classes, height, width = image_tensor.shape
-    #     hematoxylin_tensors = torch.mul(
-    #         self._transmitted_intensity,
-    #         torch.exp(
-    #             torch.matmul(-self._he_reference[:, 0].unsqueeze(-1), normalized_concentrations[0, :].unsqueeze(0))
-    #         ),
-    #     )
-    #     hematoxylin_tensors[hematoxylin_tensors > 255] = 255
-    #     hematoxylin_tensors = hematoxylin_tensors.T.reshape(batch, height, width, classes)
-    #     hematoxylin_tensors = _transpose_channels(hematoxylin_tensors)
-    #     return hematoxylin_tensors
-    #
-    # def __get_e_stain(self, normalized_concentrations: torch.Tensor, image_tensor: torch.Tensor) -> torch.Tensor:
-    #     batch, classes, height, width = image_tensor.shape
-    #     eosin_tensors = torch.mul(
-    #         self._transmitted_intensity,
-    #         torch.exp(
-    #             torch.matmul(-self._he_reference[:, 1].unsqueeze(-1), normalized_concentrations[1, :].unsqueeze(0))
-    #         ),
-    #     )
-    #     eosin_tensors[eosin_tensors > 255] = 255
-    #     eosin_tensors = eosin_tensors.T.reshape(batch, height, width, classes)
-    #     eosin_tensors = _transpose_channels(eosin_tensors)
-    #     return eosin_tensors
+    def __get_h_stain(self, normalized_concentrations: torch.Tensor, image_tensor: torch.Tensor) -> torch.Tensor:
+        """
+        Get the H-stain from the normalized concentrations.
 
-    def forward(self, *args: tuple[torch.Tensor], data_keys: Optional[list],
-                eigenvectors: Optional[torch.Tensor | None] = None) -> list[torch.Tensor]:
+        Parameters
+        ----------
+        normalized_concentrations: torch.Tensor
+            The normalized concentrations of the H&E stains in the image.
+        image_tensor: torch.Tensor
+            The image tensor to be normalized.
+
+        Returns
+        -------
+        h_stain: torch.Tensor
+            The H-stain.
+        """
+        batch, classes, height, width = image_tensor.shape
+        hematoxylin_tensors = torch.mul(
+            self._transmitted_intensity,
+            torch.exp(
+                torch.matmul(-self._he_reference[:, 0].unsqueeze(-1), normalized_concentrations[0, :].unsqueeze(0))
+            ),
+        )
+        hematoxylin_tensors[hematoxylin_tensors > 255] = 255
+        hematoxylin_tensors = hematoxylin_tensors.T.reshape(batch, height, width, classes)
+        hematoxylin_tensors = _transpose_channels(hematoxylin_tensors)
+        return hematoxylin_tensors
+
+    def __get_e_stain(self, normalized_concentrations: torch.Tensor, image_tensor: torch.Tensor) -> torch.Tensor:
+        """
+        Get the E-stain from the normalized concentrations.
+
+        Parameters
+        ----------
+        normalized_concentrations: torch.Tensor
+            The normalized concentrations of the H&E stains in the image.
+        image_tensor: torch.Tensor
+            The image tensor to be normalized.
+
+        Returns
+        -------
+        e_stain: torch.Tensor
+            The E-stain.
+        """
+        batch, classes, height, width = image_tensor.shape
+        eosin_tensors = torch.mul(
+            self._transmitted_intensity,
+            torch.exp(
+                torch.matmul(-self._he_reference[:, 1].unsqueeze(-1), normalized_concentrations[1, :].unsqueeze(0))
+            ),
+        )
+        eosin_tensors[eosin_tensors > 255] = 255
+        eosin_tensors = eosin_tensors.T.reshape(batch, height, width, classes)
+        eosin_tensors = _transpose_channels(eosin_tensors)
+        return eosin_tensors
+
+    def forward(
+        self,
+        *args: tuple[torch.Tensor],
+        data_keys: Optional[list],
+        staining_parameters: Optional[dict[str : torch.Tensor, str : torch.Tensor] | None] = None,
+    ) -> list[torch.Tensor]:
         output = []
         for sample, data_key in zip(args, data_keys):
             if data_key in ["image"]:
                 image_tensor: torch.Tensor = sample[data_key]
-                he_matrix, concentrations, maximum_concentration = self.__compute_matrices(image_tensor,
-                                                                                           eigenvectors=eigenvectors)
+                _, concentrations, maximum_concentration = self.__compute_matrices(
+                    image_tensor, staining_parameters=staining_parameters
+                )
+                if staining_parameters is not None:
+                    maximum_concentration = staining_parameters["max_wsi_concentration"]
 
                 normalized_concentrations = self.__normalize_concentrations(concentrations, maximum_concentration)
                 normalised_image = self.__create_normalized_images(normalized_concentrations, image_tensor)

--- a/ahcore/transforms/image_normalization.py
+++ b/ahcore/transforms/image_normalization.py
@@ -14,7 +14,7 @@ import torch.nn as nn
 from kornia.constants import DataKey
 
 
-def transpose_channels(tensor: torch.Tensor) -> torch.Tensor:
+def _transpose_channels(tensor: torch.Tensor) -> torch.Tensor:
     tensor = torch.transpose(tensor, 1, 3)
     tensor = torch.transpose(tensor, 2, 3)
     return tensor
@@ -101,22 +101,30 @@ class MacenkoNormalizer(nn.Module):
         self._beta = beta
         self._transmitted_intensity = transmitted_intensity
         self._return_stains = return_stains
+        if self._return_stains:
+            raise NotImplementedError("Return stains is not implemented yet.")
         self._probability = probability
         self._learnable = learnable
         self._he_reference = nn.Parameter(self.HE_REFERENCE, requires_grad=self._learnable)
         self._max_con_reference = nn.Parameter(self.MAX_CON_REFERENCE, requires_grad=self._learnable)
 
-    def convert_rgb_to_optical_density(self, image_tensor: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    def convert_rgb_to_optical_density(self, image_tensor: torch.Tensor) -> tuple[torch.Tensor, list[torch.Tensor]]:
         image_tensor = image_tensor.permute(0, 2, 3, 1)
         # calculate optical density
         optical_density = -torch.log(
-            (image_tensor.reshape((-1, image_tensor.shape[-1])).float() + 1) / self._transmitted_intensity
+            (image_tensor.reshape((image_tensor.shape[0], -1, image_tensor.shape[-1])).float() + 1) / self._transmitted_intensity
         )
         # remove transparent pixels
-        optical_density_hat = optical_density[~torch.any(optical_density < self._beta, dim=1)]
-        if optical_density_hat.numel() == 0:
-            raise RuntimeError(f"The batch contains tiles with only transparent pixels.")
+        optical_density_hat = [sample[~torch.any(sample < self._beta, dim=1)] for sample in optical_density]
         return optical_density, optical_density_hat
+
+    def convert_optical_density_to_rgb(self, od_tensor: torch.Tensor) -> torch.Tensor:
+        normalised_image_tensor = []
+        for norm_conc in od_tensor:
+            normalised_image_tensor.append(self._transmitted_intensity * torch.exp(-self._he_reference.to(norm_conc) @ norm_conc))
+        normalised_image_tensor = torch.stack(normalised_image_tensor, dim=0)
+        normalised_image_tensor[normalised_image_tensor > 255] = 255
+        return normalised_image_tensor
 
     def find_he_components(self, optical_density_hat: torch.Tensor, eigvecs: torch.Tensor) -> torch.Tensor:
         """
@@ -156,26 +164,33 @@ class MacenkoNormalizer(nn.Module):
         """
         Compute the H&E staining vectors and their concentration values for every pixel in the image tensor.
         """
+        batch_he_vecs = []
+        batch_max_con = []
+        batch_con_vecs = []
         # Convert RGB values in the image to optical density values following the Beer-Lambert's law.
         optical_density, optical_density_hat = self.convert_rgb_to_optical_density(image_tensor)
-        # Calculate the eigenvectors of optical density matrix thresholded to remove transparent pixels.
-        _, eigvecs = torch.linalg.eigh(covariance_matrix(optical_density_hat.T), UPLO="U")
-        # choose the first two eigenvectors corresponding to the two largest eigenvalues.
-        eigvecs = eigvecs[:, [1, 2]]
-        # Find the H&E staining vectors and their concentration values for every pixel in the image tensor.
-        # Note - The dependence of staining and their concentrations are linear in OD space
-        he = self.find_he_components(optical_density_hat, eigvecs)
-        # Calculate the concentrations of the H&E stains in each pixel.
-        # We do this by solving a linear system of equations. (In this case, the system is overdetermined).
-        # OD =   HE * C -> (1)
-        # where:
-        #   1. OD is the optical density of the pixels in the batch. The dimension is: (n x 3)
-        #   2. HE is the H&E staining vectors (3 x 2). The dimension is: (3 x 2)
-        #   3. C is the concentration of the H&E stains in each pixel. The dimension is: (2 x n)
-        # The solution to this system of equation is unique and is computed in the following way:
-        concentration = he.pinverse() @ optical_density.T
-        max_concentration = torch.stack([percentile(concentration[0, :], 99), percentile(concentration[1, :], 99)])
-        return he, concentration, max_concentration
+        # For every sample in the batch, calculate the eigenvectors of optical density matrix thresholded to remove transparent pixels.
+        for i in range(len(optical_density_hat)):
+            _, eigvecs = torch.linalg.eigh(covariance_matrix(optical_density_hat[i].T), UPLO="U")
+            # choose the first two eigenvectors corresponding to the two largest eigenvalues.
+            eigvecs = eigvecs[:, [1, 2]]
+            # Find the H&E staining vectors and their concentration values for every pixel in the image tensor.
+            # Note - The dependence of staining and their concentrations are linear in OD space
+            he = self.find_he_components(optical_density_hat[i], eigvecs)
+            # Calculate the concentrations of the H&E stains in each pixel.
+            # We do this by solving a linear system of equations. (In this case, the system is overdetermined).
+            # OD =   HE * C -> (1)
+            # where:
+            #   1. OD is the optical density of the pixels in the batch. The dimension is: (n x 3)
+            #   2. HE is the H&E staining vectors (3 x 2). The dimension is: (3 x 2)
+            #   3. C is the concentration of the H&E stains in each pixel. The dimension is: (2 x n)
+            # The solution to this system of equation is unique and is computed in the following way:
+            concentration = he.pinverse() @ optical_density[i].T
+            max_concentration = torch.stack([percentile(concentration[0, :], 99), percentile(concentration[1, :], 99)])
+            batch_he_vecs.append(he)
+            batch_max_con.append(max_concentration)
+            batch_con_vecs.append(concentration)
+        return torch.stack(batch_he_vecs, dim=0), torch.stack(batch_con_vecs, dim=0), torch.stack(batch_max_con, dim=0)
 
     def fit(self, image_tensor: torch.Tensor) -> None:
         he_matrix, _, maximum_concentration = self.__compute_matrices(image_tensor=image_tensor)
@@ -185,66 +200,66 @@ class MacenkoNormalizer(nn.Module):
     def __normalize_concentrations(
         self, concentrations: torch.Tensor, maximum_concentration: torch.Tensor
     ) -> torch.Tensor:
-        concentrations *= (self._max_con_reference.to(maximum_concentration) / maximum_concentration).unsqueeze(-1)
-        return concentrations
+        output = []
+        for conc, max_conc in zip(concentrations, maximum_concentration):
+            norm_conc = conc * (self._max_con_reference.to(max_conc) / max_conc).unsqueeze(-1)
+            output.append(norm_conc)
+        return torch.stack(output, dim=0)
 
     def __create_normalized_images(
         self, normalized_concentrations: torch.Tensor, image_tensor: torch.Tensor
     ) -> torch.Tensor:
         batch, classes, height, width = image_tensor.shape
         # recreate the image using reference mixing matrix
-        normalised_image_tensor = self._transmitted_intensity * torch.exp(
-            -torch.matmul(self._he_reference.to(normalized_concentrations), normalized_concentrations)
-        )
-        normalised_image_tensor[normalised_image_tensor > 255] = 255
-        normalised_image_tensor = normalised_image_tensor.T.reshape(batch, height, width, classes)
-        normalised_image_tensor = transpose_channels(normalised_image_tensor)
+        normalised_image_tensor = self.convert_optical_density_to_rgb(od_tensor=normalized_concentrations)
+        normalised_image_tensor = normalised_image_tensor.mT.reshape(batch, height, width, classes)
+        normalised_image_tensor = _transpose_channels(normalised_image_tensor)
         return normalised_image_tensor
 
-    def __get_h_stain(self, normalized_concentrations: torch.Tensor, image_tensor: torch.Tensor) -> torch.Tensor:
-        batch, classes, height, width = image_tensor.shape
-        hematoxylin_tensors = torch.mul(
-            self._transmitted_intensity,
-            torch.exp(
-                torch.matmul(-self._he_reference[:, 0].unsqueeze(-1), normalized_concentrations[0, :].unsqueeze(0))
-            ),
-        )
-        hematoxylin_tensors[hematoxylin_tensors > 255] = 255
-        hematoxylin_tensors = hematoxylin_tensors.T.reshape(batch, height, width, classes)
-        hematoxylin_tensors = transpose_channels(hematoxylin_tensors)
-        return hematoxylin_tensors
-
-    def __get_e_stain(self, normalized_concentrations: torch.Tensor, image_tensor: torch.Tensor) -> torch.Tensor:
-        batch, classes, height, width = image_tensor.shape
-        eosin_tensors = torch.mul(
-            self._transmitted_intensity,
-            torch.exp(
-                torch.matmul(-self._he_reference[:, 1].unsqueeze(-1), normalized_concentrations[1, :].unsqueeze(0))
-            ),
-        )
-        eosin_tensors[eosin_tensors > 255] = 255
-        eosin_tensors = eosin_tensors.T.reshape(batch, height, width, classes)
-        eosin_tensors = transpose_channels(eosin_tensors)
-        return eosin_tensors
+    # def __get_h_stain(self, normalized_concentrations: torch.Tensor, image_tensor: torch.Tensor) -> torch.Tensor:
+    #     batch, classes, height, width = image_tensor.shape
+    #     hematoxylin_tensors = torch.mul(
+    #         self._transmitted_intensity,
+    #         torch.exp(
+    #             torch.matmul(-self._he_reference[:, 0].unsqueeze(-1), normalized_concentrations[0, :].unsqueeze(0))
+    #         ),
+    #     )
+    #     hematoxylin_tensors[hematoxylin_tensors > 255] = 255
+    #     hematoxylin_tensors = hematoxylin_tensors.T.reshape(batch, height, width, classes)
+    #     hematoxylin_tensors = _transpose_channels(hematoxylin_tensors)
+    #     return hematoxylin_tensors
+    #
+    # def __get_e_stain(self, normalized_concentrations: torch.Tensor, image_tensor: torch.Tensor) -> torch.Tensor:
+    #     batch, classes, height, width = image_tensor.shape
+    #     eosin_tensors = torch.mul(
+    #         self._transmitted_intensity,
+    #         torch.exp(
+    #             torch.matmul(-self._he_reference[:, 1].unsqueeze(-1), normalized_concentrations[1, :].unsqueeze(0))
+    #         ),
+    #     )
+    #     eosin_tensors[eosin_tensors > 255] = 255
+    #     eosin_tensors = eosin_tensors.T.reshape(batch, height, width, classes)
+    #     eosin_tensors = _transpose_channels(eosin_tensors)
+    #     return eosin_tensors
 
     def forward(self, *args: tuple[torch.Tensor], data_keys: Optional[list]) -> list[torch.Tensor]:
         args = list(args)
         stains = {}
         image_tensor: torch.Tensor = args[0]
 
-        # TODO: Do random sampling from batch before augmentation
-        if np.random.rand() > self._probability:
-            args[0] = image_tensor
-            return args
+        # # TODO: Do random sampling from batch before augmentation
+        # if np.random.rand() > self._probability:
+        #     args[0] = image_tensor
+        #     return args
 
         he_matrix, concentrations, maximum_concentration = self.__compute_matrices(image_tensor)
 
         normalized_concentrations = self.__normalize_concentrations(concentrations, maximum_concentration)
         normalised_image = self.__create_normalized_images(normalized_concentrations, image_tensor)
         args[0] = normalised_image
-        if self._return_stains:
-            stains["image_hematoxylin"] = self.__get_h_stain(normalized_concentrations, image_tensor)
-            stains["image_eosin"] = self.__get_e_stain(normalized_concentrations, image_tensor)
+        # if self._return_stains:
+        #     stains["image_hematoxylin"] = self.__get_h_stain(normalized_concentrations, image_tensor)
+        #     stains["image_eosin"] = self.__get_e_stain(normalized_concentrations, image_tensor)
 
         return args
 

--- a/ahcore/transforms/image_normalization.py
+++ b/ahcore/transforms/image_normalization.py
@@ -6,12 +6,10 @@ Image normalization functions
 """
 from __future__ import annotations
 
-from typing import Optional
+from typing import Optional, Iterable
 
-import numpy as np
 import torch
 import torch.nn as nn
-from kornia.constants import DataKey
 
 
 def _transpose_channels(tensor: torch.Tensor) -> torch.Tensor:
@@ -73,7 +71,6 @@ class MacenkoNormalizer(nn.Module):
         transmitted_intensity: int = 240,
         return_stains: bool = False,
         probability: float = 1.0,
-        learnable: bool = True,
     ):
         """
         Normalize staining appearence of hematoxylin & eosin stained images. Based on [1].
@@ -89,8 +86,6 @@ class MacenkoNormalizer(nn.Module):
             If true, the output will also include the H&E channels
         probability : bool
             Probability of applying the transform
-        learnable : bool
-            If true, the normalization matrix will be learned during training.
         References
         ----------
         [1] A method for normalizing histology slides for quantitative analysis. M. Macenko et al., ISBI 2009
@@ -104,9 +99,8 @@ class MacenkoNormalizer(nn.Module):
         if self._return_stains:
             raise NotImplementedError("Return stains is not implemented yet.")
         self._probability = probability
-        self._learnable = learnable
-        self._he_reference = nn.Parameter(self.HE_REFERENCE, requires_grad=self._learnable)
-        self._max_con_reference = nn.Parameter(self.MAX_CON_REFERENCE, requires_grad=self._learnable)
+        self._he_reference = self.HE_REFERENCE
+        self._max_con_reference = self.MAX_CON_REFERENCE
 
     def convert_rgb_to_optical_density(self, image_tensor: torch.Tensor) -> tuple[torch.Tensor, list[torch.Tensor]]:
         image_tensor = image_tensor.permute(0, 2, 3, 1)
@@ -160,7 +154,7 @@ class MacenkoNormalizer(nn.Module):
 
         return he_vector
 
-    def __compute_matrices(self, image_tensor: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    def __compute_matrices(self, image_tensor: torch.Tensor, eigenvectors: Optional[torch.Tensor | None] = None) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         """
         Compute the H&E staining vectors and their concentration values for every pixel in the image tensor.
         """
@@ -171,9 +165,12 @@ class MacenkoNormalizer(nn.Module):
         optical_density, optical_density_hat = self.convert_rgb_to_optical_density(image_tensor)
         # For every sample in the batch, calculate the eigenvectors of optical density matrix thresholded to remove transparent pixels.
         for i in range(len(optical_density_hat)):
-            _, eigvecs = torch.linalg.eigh(covariance_matrix(optical_density_hat[i].T), UPLO="U")
-            # choose the first two eigenvectors corresponding to the two largest eigenvalues.
-            eigvecs = eigvecs[:, [1, 2]]
+            if eigenvectors is None:
+                _, eigvecs = torch.linalg.eigh(covariance_matrix(optical_density_hat[i].T), UPLO="U")
+                # choose the first two eigenvectors corresponding to the two largest eigenvalues.
+                eigvecs = eigvecs[:, [1, 2]]
+            else:
+                eigvecs = eigenvectors[i]
             # Find the H&E staining vectors and their concentration values for every pixel in the image tensor.
             # Note - The dependence of staining and their concentrations are linear in OD space
             he = self.find_he_components(optical_density_hat[i], eigvecs)
@@ -192,10 +189,28 @@ class MacenkoNormalizer(nn.Module):
             batch_con_vecs.append(concentration)
         return torch.stack(batch_he_vecs, dim=0), torch.stack(batch_con_vecs, dim=0), torch.stack(batch_max_con, dim=0)
 
-    def fit(self, image_tensor: torch.Tensor) -> None:
-        he_matrix, _, maximum_concentration = self.__compute_matrices(image_tensor=image_tensor)
-        self._he_reference = nn.Parameter(he_matrix, requires_grad=self._learnable)
-        self._max_con_reference = nn.Parameter(maximum_concentration, requires_grad=self._learnable)
+    def fit(self, tile_iterator: Iterable, reduce: str = "mean") -> torch.Tensor | list[torch.Tensor]:
+        if not hasattr(self, '_eigenvectors'):
+            setattr(self, "_eigenvectors", [])
+        for tile in tile_iterator:
+            _, optical_density_hat = self.convert_rgb_to_optical_density(tile.unsqueeze(0))
+            _, _eigvecs = torch.linalg.eigh(covariance_matrix(optical_density_hat[0].T), UPLO="U")
+            # choose the first two eigenvectors corresponding to the two largest eigenvalues.
+            tile_level_eigenvecs = _eigvecs[:, [1, 2]]
+            self._eigenvectors.append(tile_level_eigenvecs)
+        if reduce == "resultant":
+            # Return the resultant of the eigenvectors
+            resultant = torch.stack(self._eigenvectors, dim=0).sum(dim=0)
+            # Normalise the resultant
+            resultant = resultant / torch.linalg.norm(resultant, dim=0)
+            return resultant
+        elif reduce == "raw":
+            return torch.stack(self._eigenvectors, dim=0)
+
+    def set(self, target_image: torch.Tensor) -> None:
+        he_matrix, _, maximum_concentration = self.__compute_matrices(image_tensor=target_image)
+        self._he_reference = he_matrix
+        self._max_con_reference = maximum_concentration
 
     def __normalize_concentrations(
         self, concentrations: torch.Tensor, maximum_concentration: torch.Tensor
@@ -242,7 +257,7 @@ class MacenkoNormalizer(nn.Module):
     #     eosin_tensors = _transpose_channels(eosin_tensors)
     #     return eosin_tensors
 
-    def forward(self, *args: tuple[torch.Tensor], data_keys: Optional[list]) -> list[torch.Tensor]:
+    def forward(self, *args: tuple[torch.Tensor], data_keys: Optional[list], eigenvectors: Optional[torch.Tensor | None] = None) -> list[torch.Tensor]:
         args = list(args)
         stains = {}
         image_tensor: torch.Tensor = args[0]
@@ -252,7 +267,7 @@ class MacenkoNormalizer(nn.Module):
         #     args[0] = image_tensor
         #     return args
 
-        he_matrix, concentrations, maximum_concentration = self.__compute_matrices(image_tensor)
+        he_matrix, concentrations, maximum_concentration = self.__compute_matrices(image_tensor, eigenvectors=eigenvectors)
 
         normalized_concentrations = self.__normalize_concentrations(concentrations, maximum_concentration)
         normalised_image = self.__create_normalized_images(normalized_concentrations, image_tensor)

--- a/ahcore/transforms/image_normalization.py
+++ b/ahcore/transforms/image_normalization.py
@@ -55,7 +55,6 @@ def load_stainings_from_cache(filenames: list[str]) -> dict:
         he, max_con = load_vector_from_h5_file(Path(filename).stem)
         hes.append(he)
         max_concentrations.append(max_con)
-    breakpoint()
     staining_parameters["wsi_staining_vectors"] = torch.stack(hes)
     staining_parameters["max_wsi_concentration"] = torch.stack(max_concentrations)
     return staining_parameters
@@ -423,8 +422,11 @@ class MacenkoNormalizer(nn.Module):
     def forward(self, *args: tuple[torch.Tensor], **kwargs) -> list[torch.Tensor]:
         output = []
         sample = args[0]
-        filenames = kwargs["filenames"]
-        staining_parameters = load_stainings_from_cache(filenames)
+        if kwargs["staining_parameters"]:
+            staining_parameters = kwargs["staining_parameters"]
+        else:
+            filenames = kwargs["filenames"]
+            staining_parameters = load_stainings_from_cache(filenames)
         concentrations = self.__compute_matrices(sample, staining_parameters=staining_parameters)
         wsi_maximum_concentration = staining_parameters["max_wsi_concentration"]
         normalized_concentrations = self.__normalize_concentrations(concentrations, wsi_maximum_concentration)

--- a/ahcore/utils/data.py
+++ b/ahcore/utils/data.py
@@ -50,6 +50,8 @@ class DataDescription:
     data_dir: Path
     manifest_path: Path
     dataset_split_path: Optional[Path]
+    center_info_path: Optional[Path]
+    centers: Optional[list[str]]
     annotations_dir: Path
 
     training_grid: GridDescription
@@ -57,6 +59,7 @@ class DataDescription:
 
     index_map: Optional[dict[str, int]]
     max_val_tiffs: Optional[int] = None
+    extract_center: Optional[bool] = False
     remap_labels: Optional[dict[str, str]] = None
     colors: Optional[dict[str, str]] = None
     use_class_weights: Optional[bool] = False

--- a/ahcore/utils/data.py
+++ b/ahcore/utils/data.py
@@ -53,6 +53,7 @@ class DataDescription:
     center_info_path: Optional[Path]
     centers: Optional[list[str]]
     annotations_dir: Path
+    compute_staining: bool
 
     training_grid: GridDescription
     inference_grid: GridDescription

--- a/ahcore/utils/manifest.py
+++ b/ahcore/utils/manifest.py
@@ -51,8 +51,9 @@ _ImageBackends = {
     "OPENSLIDE": ImageBackend.OPENSLIDE,
 }
 
-AnnotationReaders = Enum(value="AnnotationReaders",
-                         names=[(field, field) for field in _AnnotationReaders.keys()])  # type: ignore
+AnnotationReaders = Enum(
+    value="AnnotationReaders", names=[(field, field) for field in _AnnotationReaders.keys()]
+)  # type: ignore
 ImageBackends = Enum(value="ImageBackends", names=[(field, field) for field in _ImageBackends.keys()])  # type: ignore
 
 
@@ -169,8 +170,9 @@ def manifests_from_data_description(data_description: DataDescription) -> Splitt
     return splitted_manifest
 
 
-def parse_wsi_attributes_from_manifest(data_description: DataDescription, manifest: ImageManifest) -> tuple[
-    Path, _ImageBackends, float | None]:
+def parse_wsi_attributes_from_manifest(
+    data_description: DataDescription, manifest: ImageManifest
+) -> tuple[Path, _ImageBackends, float | None]:
     overwrite_mpp = None
     if manifest.mpp:
         overwrite_mpp = (manifest.mpp, manifest.mpp)
@@ -181,7 +183,7 @@ def parse_wsi_attributes_from_manifest(data_description: DataDescription, manife
 
 
 def _parse_annotations(
-        annotation_model: AnnotationModel | None, *, base_dir: Path
+    annotation_model: AnnotationModel | None, *, base_dir: Path
 ) -> WsiAnnotations | SlideImage | None:
     _annotations = None
     if not annotation_model:
@@ -203,14 +205,14 @@ def _parse_annotations(
 
 
 def image_manifest_to_dataset(
-        data_description: DataDescription,
-        manifest: ImageManifest,
-        mpp: Optional[float],
-        tile_size: tuple[int, int],
-        tile_overlap: tuple[int, int],
-        output_tile_size: tuple[int, int] | None = None,
-        transform: Optional[Callable] = None,
-        stage: str = TrainerFn.FITTING,
+    data_description: DataDescription,
+    manifest: ImageManifest,
+    mpp: Optional[float],
+    tile_size: tuple[int, int],
+    tile_overlap: tuple[int, int],
+    output_tile_size: tuple[int, int] | None = None,
+    transform: Optional[Callable] = None,
+    stage: str = TrainerFn.FITTING,
 ) -> TiledROIsSlideImageDataset:
     """Create a `TiledROIsSlideImageDataset` from an `ImageManifest`.
 

--- a/ahcore/utils/manifest.py
+++ b/ahcore/utils/manifest.py
@@ -51,7 +51,8 @@ _ImageBackends = {
     "OPENSLIDE": ImageBackend.OPENSLIDE,
 }
 
-AnnotationReaders = Enum(value="AnnotationReaders", names=[(field, field) for field in _AnnotationReaders.keys()])  # type: ignore
+AnnotationReaders = Enum(value="AnnotationReaders",
+                         names=[(field, field) for field in _AnnotationReaders.keys()])  # type: ignore
 ImageBackends = Enum(value="ImageBackends", names=[(field, field) for field in _ImageBackends.keys()])  # type: ignore
 
 
@@ -168,8 +169,15 @@ def manifests_from_data_description(data_description: DataDescription) -> Splitt
     return splitted_manifest
 
 
+def parse_wsi_attributes_from_manifest(data_description: DataDescription, manifest: ImageManifest) -> tuple[Path, _ImageBackends]:
+    image_fn, _image_backend = manifest.image
+    image_fn = data_description.data_dir / image_fn
+    image_backend = _ImageBackends[_image_backend.name]
+    return image_fn, image_backend
+
+
 def _parse_annotations(
-    annotation_model: AnnotationModel | None, *, base_dir: Path
+        annotation_model: AnnotationModel | None, *, base_dir: Path
 ) -> WsiAnnotations | SlideImage | None:
     _annotations = None
     if not annotation_model:
@@ -191,14 +199,14 @@ def _parse_annotations(
 
 
 def image_manifest_to_dataset(
-    data_description: DataDescription,
-    manifest: ImageManifest,
-    mpp: Optional[float],
-    tile_size: tuple[int, int],
-    tile_overlap: tuple[int, int],
-    output_tile_size: tuple[int, int] | None = None,
-    transform: Optional[Callable] = None,
-    stage: str = TrainerFn.FITTING,
+        data_description: DataDescription,
+        manifest: ImageManifest,
+        mpp: Optional[float],
+        tile_size: tuple[int, int],
+        tile_overlap: tuple[int, int],
+        output_tile_size: tuple[int, int] | None = None,
+        transform: Optional[Callable] = None,
+        stage: str = TrainerFn.FITTING,
 ) -> TiledROIsSlideImageDataset:
     """Create a `TiledROIsSlideImageDataset` from an `ImageManifest`.
 
@@ -226,10 +234,8 @@ def image_manifest_to_dataset(
     TiledROIsSlideImageDataset
         A `TiledROIsSlideImageDataset` object.
     """
-    image_fn, _image_backend = manifest.image
-    image_fn = data_description.data_dir / image_fn
-    image_backend = _ImageBackends[_image_backend.name]
-
+    # This line parses image path and backend from the manifest
+    image_fn, image_backend = parse_wsi_attributes_from_manifest(data_description, manifest)
     # This block parses the annotations
     _annotations = _parse_annotations(manifest.annotations, base_dir=data_description.annotations_dir)
 

--- a/config/augmentations/segmentation_macenko.yaml
+++ b/config/augmentations/segmentation_macenko.yaml
@@ -1,0 +1,11 @@
+# Below we set up transforms for each stage in pytorch lightning
+# the '@name' behind the renames the config to 'name' -- allows us to re-use the validation config for other stages
+# To override specific values you can use the expected override, e.g., 'transforms.predict.probability=0'
+# We can, however, also override groups, albeit a bit more unfamiliar: 'transforms/stages@transforms.predict=train_seg'
+
+defaults:
+  - _self_
+  - /augmentations/stages@fit: train_seg_macenko
+  - /augmentations/stages@validate: val_seg_macenko
+  - /augmentations/stages@test: val_seg
+  - /augmentations/stages@predict: val_seg

--- a/config/augmentations/segmentation_macenko.yaml
+++ b/config/augmentations/segmentation_macenko.yaml
@@ -7,5 +7,5 @@ defaults:
   - _self_
   - /augmentations/stages@fit: train_seg_macenko
   - /augmentations/stages@validate: val_seg_macenko
-  - /augmentations/stages@test: val_seg
-  - /augmentations/stages@predict: val_seg
+  - /augmentations/stages@test: val_seg_macenko
+  - /augmentations/stages@predict: val_seg_macenko

--- a/config/augmentations/stages/train_seg.yaml
+++ b/config/augmentations/stages/train_seg.yaml
@@ -1,4 +1,4 @@
-_target_: ahcore.augmentations.AugmentationFactory
+_target_: ahcore.transforms.augmentations.AugmentationFactory
 
 # These transforms will be applied in order as a first step.
 initial_transforms:

--- a/config/augmentations/stages/train_seg_macenko.yaml
+++ b/config/augmentations/stages/train_seg_macenko.yaml
@@ -1,0 +1,80 @@
+_target_: ahcore.transforms.augmentations.AugmentationFactory
+
+# These transforms will be applied in order as a first step.
+
+initial_transforms:
+  - _target_: ahcore.transforms.image_normalization.MacenkoNormalizer
+    alpha: 1.0
+    beta: 0.15
+    transmitted_intensity: 240.0
+    return_stains: False
+    probability: 1.0
+
+  - _target_: ahcore.transforms.augmentations.MeanStdNormalizer
+    mean: ${data_description.normalize_mean}
+    std: ${data_description.normalize_std}
+
+
+# [a, b] select between a and b random intensity transforms to apply.
+# If True, will select all in a random order. If False, will apply all sequentially.
+random_apply_intensity: [1,]
+random_apply_weights_intensity: null
+intensity_augmentations:
+  - _target_: kornia.augmentation.RandomGaussianBlur
+    p: 0.5
+    kernel_size: [9, 9]
+    sigma: [0.1, 1.0]
+  - _target_: kornia.augmentation.RandomSharpness
+    p: 0.5
+    sharpness: 10
+  - _target_: kornia.augmentation.ColorJitter
+    p: 0.5
+    brightness: 0.05
+    contrast: 0.05
+    saturation: 0.05
+    hue: 0.05
+#  - _target_: kornia.augmentation.RandomSaturation
+#    p: 0.5
+#    saturation: [0.5, 2.0]
+
+# [a, b] select between a and b random geometric transforms to apply.
+# If True, will select all in a random order. If False, will apply all sequentially.
+random_apply_geometric: [1,]
+random_apply_weights_geometric: null
+geometric_augmentations:
+    - _target_: kornia.augmentation.RandomHorizontalFlip
+      p: 0.5
+    - _target_: kornia.augmentation.RandomVerticalFlip
+      p: 0.5
+    - _target_: kornia.augmentation.RandomPerspective
+      p: 0.5
+      distortion_scale: 0.5
+    - _target_: kornia.augmentation.RandomAffine
+      p: 0.5
+      degrees: [0.0, 90.0]
+      scale: null
+      translate: null
+      shear: null
+    - _target_: kornia.augmentation.RandomAffine
+      p: 0.5
+      degrees: 0
+      scale: [0.75, 1.0]
+      translate: null
+      shear: null
+    - _target_: kornia.augmentation.RandomAffine
+      p: 0.5
+      degrees: 0
+      scale: null
+      translate: [0, 0.05] # This is given in percentages
+      shear: null
+    - _target_: kornia.augmentation.RandomAffine
+      p: 0.5
+      degrees: 0
+      scale: null
+      translate: null
+      shear: [0, 5]
+
+# These transforms are applied in order as a final step.
+final_transforms:
+  - _target_: ahcore.transforms.augmentations.CenterCrop
+    size: [512, 512]

--- a/config/augmentations/stages/val_seg.yaml
+++ b/config/augmentations/stages/val_seg.yaml
@@ -1,4 +1,4 @@
-_target_: ahcore.augmentations.AugmentationFactory
+_target_: ahcore.transforms.augmentations.AugmentationFactory
 
 # These transforms will be applied in order as a first step.
 initial_transforms:

--- a/config/augmentations/stages/val_seg_macenko.yaml
+++ b/config/augmentations/stages/val_seg_macenko.yaml
@@ -1,0 +1,17 @@
+_target_: ahcore.transforms.augmentations.AugmentationFactory
+
+# These transforms will be applied in order as a first step.
+initial_transforms:
+  - _target_: ahcore.transforms.image_normalization.MacenkoNormalizer
+    alpha: 1.0
+    beta: 0.15
+    transmitted_intensity: 240.0
+    return_stains: False
+    probability: 1.0
+  - _target_: ahcore.transforms.augmentations.MeanStdNormalizer
+    mean: ${data_description.normalize_mean}
+    std: ${data_description.normalize_std}
+
+intensity_augmentations: null
+geometric_augmentations: null
+final_transforms: null

--- a/config/datamodule/dataset.yaml
+++ b/config/datamodule/dataset.yaml
@@ -1,3 +1,4 @@
 _target_: ahcore.data.dataset.DlupDataModule
 batch_size: ???  # specify in machine_settings
 num_workers: ???  # specify in machine_settings
+compute_staining: False

--- a/config/lit_module/attention_unet.yaml
+++ b/config/lit_module/attention_unet.yaml
@@ -3,10 +3,11 @@ _target_: ahcore.lit_module.AhCoreLightningModule
 model:
   _target_: ahcore.models.attention_unet.AttentionUnet
   _partial_: true
-  num_input_ch: 3
+  inp_channel: 3
+  kernel_multiplier: 7
   depth: 4
-  num_initial_filters: 96
-  dropout_prob: 0.1
+  dropout_rate: 0.1
+  return_features: True
 
 optimizer:
   _target_: torch.optim.Adam

--- a/config/metrics/segmentation.yaml
+++ b/config/metrics/segmentation.yaml
@@ -3,3 +3,26 @@ tile_level:
 
 wsi_level:
   _target_: ahcore.metrics.WSIMetricFactory.for_segmentation
+
+prediction_robustness:
+  _target_: ahcore.metrics.epoch_metrics.PredictionAUCRobustness
+  target_key: "center"
+  target_aggregations: ["min", "max", "mean", "std"]
+
+feature_robustness:
+  _target_: ahcore.metrics.epoch_metrics.FeatureAUCRobustness
+  target_key: "center"
+  feature_layer: 0
+  features_patch_aggregation: "mean"
+  features_per_target_aggregation: "mean"
+  target_aggregations: ["min", "max", "mean", "std"]
+
+linear_probing:
+  _target_: ahcore.metrics.epoch_metrics.LinearModelFeatureRobustness
+  target_key: "center"
+  feature_layer: 0
+  features_patch_aggregation: "mean"
+  target_aggregations: [ "min", "max", "mean", "std" ]
+  model_name: "LogisticRegression"
+  test_size: 0.3
+  scoring: "accuracy"

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ install_requires = [
     "hydra-submitit-launcher>=1.2.0",
     "hydra-optuna-sweeper>=1.2.0",
     "hydra-colorlog>=1.2.0",
-    "dlup>=0.3.20",
+    "dlup>=0.3.24",
     "kornia>=0.6.9",
     "h5py",
     "escnn",  # To use equivariant unets


### PR DESCRIPTION
Fixes {#16}

This PR makes the following changes:

-   Added `MacenkoNormalization` to the initial transforms.

-   Added relevant config files for it.

-   Modified the forward method of the `MacenkoNormalization` so that it's compatible with ahcore.

-   Introduced the `fit()` function that computes the staining vectors of WSIs with an option of dumping them to cache for quick computation during training.


| Normalization applied on whole image (No resampling)  | Normalisation applied on individual tiles ( No resampling) |
| ------------- | ------------- |
|![image](https://user-images.githubusercontent.com/26798611/232772667-d5003979-de48-4303-b9cd-dc4f7fb7bf2b.png)| ![image](https://user-images.githubusercontent.com/26798611/232772594-3c3f9170-cff3-4609-b3e7-8c80196c14e2.png)|

![image](https://user-images.githubusercontent.com/26798611/232774333-ff7ecae0-1254-48ba-8182-082f62a1ac87.png)

| SSIM between normalised WSI and Tile normalised WSI | PSNR between normalised WSI and Tile normalised |
| :-------------------------------------------------------------: | :---------------------------------------------------------: |
|  0.9499 | 29.568 |

![image](https://user-images.githubusercontent.com/26798611/232780075-73f8cbdd-7f83-44b0-867f-adbb9aeafa3b.png)



