### PR TITLE
HE normalization

### DIFF
--- a/ahcore/transforms/image_normalization.py
+++ b/ahcore/transforms/image_normalization.py
@@ -184,6 +184,16 @@ class MacenkoNormalizer(nn.Module):
         self._max_con_reference = self.MAX_CON_REFERENCE
 
     def _get_con_scaling_bias(self, filenames: list[str]) -> None:
+        """
+        Cache the scaling factors and the biases.
+        Parameters
+        ----------
+        filenames
+
+        Returns
+        -------
+
+        """
         sigma = torch.tensor(0.5)
         _from = torch.FloatTensor(1).uniform_(-10, 0).item()
         _to = torch.FloatTensor(1).uniform_(0, 10).item()
@@ -195,6 +205,8 @@ class MacenkoNormalizer(nn.Module):
 
     def _augment_he_con(self, he_con_vector: torch.Tensor, filenames: list[str]) -> torch.Tensor:
         """
+        Augment concentrations of H and E stains.
+
         Parameters
         ----------
         he_con_vector: torch.Tensor

--- a/ahcore/transforms/image_normalization.py
+++ b/ahcore/transforms/image_normalization.py
@@ -184,7 +184,7 @@ class MacenkoNormalizer(nn.Module):
         self._max_con_reference = self.MAX_CON_REFERENCE
 
     def _get_con_scaling_bias(self, filenames: list[str]) -> None:
-        sigma = torch.tensor(0.9)
+        sigma = torch.tensor(0.5)
         _from = torch.FloatTensor(1).uniform_(-10, 0).item()
         _to = torch.FloatTensor(1).uniform_(0, 10).item()
         for filename in filenames:

--- a/ahcore/transforms/image_normalization.py
+++ b/ahcore/transforms/image_normalization.py
@@ -498,8 +498,11 @@ class MacenkoNormalizer(nn.Module):
         sample = args[0]
         if "overwrite_mpp" in kwargs.keys():
             setattr(self, "_overwrite_mpp", kwargs["overwrite_mpp"])
-        filenames = kwargs["filenames"]
-        staining_parameters = self._get_staining_vectors_from_cache_or_file(filenames)
+        if "staining_parameters" in kwargs.keys():
+            staining_parameters = kwargs["staining_parameters"]
+        else:
+            filenames = kwargs["filenames"]
+            staining_parameters = self._get_staining_vectors_from_cache_or_file(filenames)
         tile_concentrations = self.__compute_matrices(sample, staining_parameters=staining_parameters)
         wsi_maximum_concentration = staining_parameters["max_wsi_concentration"]
         if self._he_con_augment:

--- a/config/augmentations/stages/train_seg_macenko.yaml
+++ b/config/augmentations/stages/train_seg_macenko.yaml
@@ -9,6 +9,7 @@ initial_transforms:
     return_stains: False
     probability: 1.0
     requested_mpp: 16.0
+    augment_he_concentrations: False
   - _target_: ahcore.transforms.augmentations.MeanStdNormalizer
     mean: [0.0, 0.0, 0.0]
     std: [1.0, 1.0, 1.0]

--- a/config/augmentations/stages/val_seg_macenko.yaml
+++ b/config/augmentations/stages/val_seg_macenko.yaml
@@ -9,6 +9,7 @@ initial_transforms:
     return_stains: False
     probability: 1.0
     requested_mpp: 16.0
+    augment_he_concentrations: False
   - _target_: ahcore.transforms.augmentations.MeanStdNormalizer
     mean: [0.0, 0.0, 0.0]
     std: [1.0, 1.0, 1.0]


### PR DESCRIPTION
This PR introduces a pathology specific augmentation. It is inspired from [Tellez et.al](https://arxiv.org/pdf/1808.05896.pdf).

Below, are examples of an image that has been normalised using Macenko along with augmentations in the HE space.

![image](https://github.com/NKI-AI/ahcore/assets/26798611/e7ffd3d7-a586-4138-af88-586cc7bb3ee5)

On WSIs, it produces a variety of colors in the HE space.

![image](https://github.com/NKI-AI/ahcore/assets/26798611/f7651354-417c-4b17-9252-43a900dc508f)
