### PR TITLE
add offset to reading the wsi region from the slide image. 

### DIFF
--- a/ahcore/transforms/image_normalization.py
+++ b/ahcore/transforms/image_normalization.py
@@ -443,7 +443,7 @@ class MacenkoNormalizer(nn.Module):
                     scaled_wsi = slide_image.get_scaled_view(scaling)
 
                     offset, bounds = slide_image.slide_bounds
-                    offset = tuple((np.asarray(offset) * scaling).astype(int))
+                    offset = tuple((torch.tensor(offset) * scaling).to(torch.int))
                     scaled_size = int(bounds[0] * scaling), int(bounds[1] * scaling)
                     logger.info(
                         "Computing Macenko staining vector for %s resized to %s (mpp=%s).",


### PR DESCRIPTION
This is needed for the P1000 images, which have a large amount of white background in the slide images. Without the offset, the stain vectors are computed across a part of the slide image that mostly contains white background area. Aperio images do not have white background and therefore the offset was not needed before.

Fixes #23 
