### PR TITLE
Bugfix/hed color augmentation fix

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,7 @@ repos:
         entry: mypy
         language: system
         types: [python]
-        args: ["ahcore", "--strict"]
+        args: ["--strict"]
 -   repo: https://github.com/Yelp/detect-secrets
     rev: v1.4.0
     hooks:

--- a/ahcore/transforms/augmentations.py
+++ b/ahcore/transforms/augmentations.py
@@ -78,7 +78,7 @@ class HEDColorAugmentation(K.IntensityAugmentationBase2D):
         scale_sigma: float | list[float] | ListConfig,
         bias_sigma: float | list[float] | ListConfig,
         epsilon: float = 1e-6,
-        clamp_output_range: Optional[tuple[float, float]] = None,
+        clamp_output_range: Optional[tuple[float, float]] = (0, 1),
         p: float = 0.5,
         p_batch: float = 1.0,
         same_on_batch: bool = False,
@@ -97,6 +97,16 @@ class HEDColorAugmentation(K.IntensityAugmentationBase2D):
             For each channel in the HED space a random bias is added drawn from beta_i ~ U(-sigma_i,sigma_i).
         epsilon: float
             Small positive bias to avoid numerical errors
+        clamp_output_range: tuple of floats or None
+            Clamp output in range after augmenting the input. Conventionally a range of [0, 1] is used, but this will
+            discard some color information. `scale_sigma` and `bias_sigma` should be chosen carefully to prevent this.
+
+        NOTE: To reproduce augmentations as shown in [3], a larger positive bias of `epsilon=2` in combination with
+        `clamp_output_range=(0, 1)` should be used. Then, use `scale_sigma=bias_sigma=0.05` for `HED-light` and
+        `scale_sigma=bias_sigma=0.2` for `HED-strong`.
+        When using the default `epsilon=1e-6` and `clamp_output_range=(0, 1)`, this is not equal but comparable to
+        `scale_sigma=bias_sigma=0.15` for `HED-light` and `scale_sigma=bias_sigma=0.8` for `HED-strong`?
+
 
         References
         ----------
@@ -105,6 +115,9 @@ class HEDColorAugmentation(K.IntensityAugmentationBase2D):
             IEEE transactions on medical imaging 37.9 (2018): 2126-2136.
         [2] Ruifrok AC, Johnston DA. Quantification of histochemical staining by color deconvolution.
             Anal Quant Cytol Histol. 2001 Aug;23(4):291-9. PMID: 11531144.
+        [3] Tellez, David, et al. "Quantifying the effects of data augmentation and stain color normalization
+            in convolutional neural networks for computational pathology."
+            Medical image analysis 58 (2019): 101544.
         """
         super().__init__(p=p, p_batch=p_batch, same_on_batch=same_on_batch, keepdim=keepdim)
         if (isinstance(scale_sigma, (list, ListConfig)) and len(scale_sigma) != 3) or (


### PR DESCRIPTION
Fixes [#{11}](https://github.com/NKI-AI/ahcore/issues/11). 

This pull request changes the following:

1. Modified the .pre-commit-config.yaml to only include the argument `--strict` so mypy will read the changed files.
2. Modified the `apply_transform` function to apply color transform on the whole HED range instead of just on values bigger than `epsilon`.
3. Added a `clamp_output_range` parameter to clamp the output between two values.
4. Added documentation on how to reproduce results from follow up paper by [Tellez et al. (2019)](https://arxiv.org/abs/1902.06543).

Tellez et al. uses `epsilon=2` (on values in a range [0-1]) and effectively clip their output with `clamp_output_range=(0, 1)`. The reported values with a normal small positive bias of `epsilon=1e-6` in the docstring were determined by visual inspection made with [the implementation from Tellez et al. in this file](https://gist.github.com/BPdeRooij/659c81d32f688f3f96de59a94951dda0). These results are comparable, but will not be exact because the optical density calculation and subsequent color deconvolution is done on a range of `[epsilon, 1 + epsilon]` (where `epsilon=1e-6`) instead of `[2, 3]`.
