### PR TITLE
limit_bounds can always be set to True with upstream dlup.

### DIFF
--- a/ahcore/utils/manifest.py
+++ b/ahcore/utils/manifest.py
@@ -341,7 +341,7 @@ def datasets_from_data_description(
                 transform=transform,
                 backend=ImageBackend[str(image.reader)],
                 overwrite_mpp=(image.mpp, image.mpp),
-                limit_bounds=False if rois is not None else True,
+                limit_bounds=True,
             )
 
             yield dataset

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ install_requires = [
     "hydra-submitit-launcher>=1.2.0",
     "hydra-optuna-sweeper>=1.3.0.dev0",
     "hydra-colorlog>=1.2.0",
-    "dlup>=0.3.32",
+    "dlup>=0.3.33",
     "kornia>=0.7.0",
     "h5py>=3.8.0",
     "monai[einops]==1.2.0",


### PR DESCRIPTION
This sets `limit_bounds` always to True. This depends on the merging of https://github.com/NKI-AI/dlup/pull/201