### PR TITLE
Add drop_last parameter to WsiBatchSamplerPredict

### DIFF
--- a/ahcore/data/samplers.py
+++ b/ahcore/data/samplers.py
@@ -65,7 +65,7 @@ class WsiBatchSamplerPredict(Sampler[List[int]]):
         self,
         sampler: SequentialSampler | None = None,
         batch_size: int | None = None,
-        drop_last: bool | None = None,
+        drop_last: bool = False,
         dataset: ConcatDataset[TiledROIsSlideImageDataset] | None = None,
     ) -> None:
         if sampler is not None:  # During the predict phase, the sampler is passed as a parameter
@@ -74,7 +74,7 @@ class WsiBatchSamplerPredict(Sampler[List[int]]):
             self._dataset: ConcatDataset[TiledROIsSlideImageDataset] = dataset  # type: ignore
         super().__init__(data_source=self._dataset)
         self.batch_size = batch_size
-        self.drop_last = drop_last
+        self.drop_last = False  # This is needed for compatibility with Lightning, it serves no functional purpose
 
         self._slices: List[slice] = []
         self._populate_slices()

--- a/ahcore/data/samplers.py
+++ b/ahcore/data/samplers.py
@@ -74,6 +74,7 @@ class WsiBatchSamplerPredict(Sampler[List[int]]):
             self._dataset: ConcatDataset[TiledROIsSlideImageDataset] = dataset  # type: ignore
         super().__init__(data_source=self._dataset)
         self.batch_size = batch_size
+        self.drop_last = drop_last
 
         self._slices: List[slice] = []
         self._populate_slices()


### PR DESCRIPTION
Minor bug fix for inference. The WsiBatchSamplerPredict has the same functionality as WsiBatchSampler, except it has a different signature to interface with the lightning predict loop.
It was missing the drop_last attribute, causing an error during inference due to https://github.com/Lightning-AI/lightning/blob/482da0a14092f50f75b85a06a5ce353b8b81719b/src/lightning/pytorch/utilities/data.py#L278 .


