### PR TITLE
Fix for OOM during inference

### DIFF
--- a/ahcore/entrypoints.py
+++ b/ahcore/entrypoints.py
@@ -268,7 +268,7 @@ def inference(config: DictConfig) -> None:
 
     # Inference
     logger.info("Starting inference...")
-    trainer.predict(model=model, datamodule=datamodule)
+    trainer.predict(model=model, datamodule=datamodule, return_predictions=False)
 
     # Make sure everything closed properly
     logger.info("Finalizing...")


### PR DESCRIPTION
Pytorch Lightning keeps track of all its outputs through one epoch. That is why, we observed the OOM error during the predict loop. If we disable the `return_predictions` flag, OOM errors don't occur anymore. For a detailed discussion on this, refer the comments on #19.
