### PR TITLE
Implement {#18}

### DIFF
--- a/config/callbacks/write_tiff_callback.yaml
+++ b/config/callbacks/write_tiff_callback.yaml
@@ -1,2 +1,3 @@
 write_tiff_callback:
   _target_: ahcore.callbacks.WriteTiffCallback
+  delete_original_h5: true # Make sure delete_original_h5 is enabled only for the last callback which uses h5 files.


### PR DESCRIPTION
Addresses {#18}

With the changes in this PR, ahcore deletes H5 files that are stored on the disc during inference after their corresponding files have been written.
