### PR TITLE
Added colormaps to tiffwriter. 

### DIFF
--- a/config/callbacks/default.yaml
+++ b/config/callbacks/default.yaml
@@ -35,6 +35,7 @@ write_h5_callback:
 
 write_tiff_callback:
   max_concurrent_writers: 4
+  colormap: ${data_description.color_map}
 
 compute_wsi_metrics_callback:
   max_processes: 4


### PR DESCRIPTION
Fixes #47

This PR enables ahcore segmentation pipeline to output tiff images with color look up tables so that the visualization is easy on third party applications. Below is an example output.  On the top we see an image from slidescore, below it, we see model predictions on it.

![image (22)](https://github.com/NKI-AI/ahcore/assets/26798611/4ca9f671-f122-4658-a424-d32adf2d0ca5)

![image](https://github.com/NKI-AI/ahcore/assets/26798611/9585fe8a-cc6e-46e3-9142-0c0f15d6b95b)



