### PR TITLE
H5 Writer for feature vectors.

### DIFF
--- a/ahcore/cli/data.py
+++ b/ahcore/cli/data.py
@@ -1,6 +1,5 @@
 """Module to write copy manifests files over to SCRATCH directory"""
 from __future__ import annotations
-
 import argparse
 import hashlib
 import os

--- a/ahcore/cli/data.py
+++ b/ahcore/cli/data.py
@@ -1,5 +1,6 @@
 """Module to write copy manifests files over to SCRATCH directory"""
 from __future__ import annotations
+
 import argparse
 import hashlib
 import os

--- a/ahcore/utils/types.py
+++ b/ahcore/utils/types.py
@@ -38,7 +38,7 @@ class NormalizationType(str, Enum):
     SOFTMAX = "softmax"
     LOGITS = "logits"
 
-    def normalize(self) -> Callable:
+    def normalize(self) -> Callable[..., Any]:
         if self == NormalizationType.SIGMOID:
             return torch.sigmoid
         elif self == NormalizationType.SOFTMAX:
@@ -54,12 +54,12 @@ class InferencePrecision(str, Enum):
     FP32 = "float32"
     UINT8 = "uint8"
 
-    def get_multiplier(self) -> float:
+    def get_multiplier(self) -> GenericArray:
         if self == InferencePrecision.FP16:
-            return 1.0
+            return np.array(1.0).astype(np.float16)
         elif self == InferencePrecision.FP32:
-            return 1.0
+            return np.array(1.0).astype(np.float32)
         elif self == InferencePrecision.UINT8:
-            return 255.0
+            return np.array(255.0).astype(np.uint8)
         else:
             raise NotImplementedError(f"Precision {self} is not supported for {self.__class__.__name__}.")

--- a/ahcore/utils/types.py
+++ b/ahcore/utils/types.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import Any
+from typing import Any, Callable
 
 import numpy as np
 import numpy.typing as npt
@@ -38,7 +38,7 @@ class NormalizationType(str, Enum):
     SOFTMAX = "softmax"
     LOGITS = "logits"
 
-    def normalize(self):
+    def normalize(self) -> Callable:
         if self == NormalizationType.SIGMOID:
             return torch.sigmoid
         elif self == NormalizationType.SOFTMAX:

--- a/ahcore/writers.py
+++ b/ahcore/writers.py
@@ -100,7 +100,9 @@ class H5TileFeatureWriter:
 
     @staticmethod
     def _feature_generator(
-        first_feature_coordinates: GenericArray, first_features: GenericArray, feature_generator: Generator[Any, None, None]
+        first_feature_coordinates: GenericArray,
+        first_features: GenericArray,
+        feature_generator: Generator[Any, None, None],
     ) -> Generator[Any, None, None]:
         # We plug the first coordinates and the first features back into the generator
         # That way, we can yield them while h5 writing.

--- a/ahcore/writers.py
+++ b/ahcore/writers.py
@@ -76,11 +76,9 @@ class H5TileFeatureWriter:
         try:
             with h5py.File(self._filename.with_suffix(".h5.partial"), "w") as h5file:
                 first_features, first_batch = next(feature_generator)
-                self.init_writer(first_features)
+                self.init_writer(first_features, h5file)
 
                 assert self._tile_feature_dataset, "Tile feature dataset is not initialized"
-
-                feature_generator = self._feature_generator((first_features, first_batch), feature_generator)
 
                 for coordinates, feature in feature_generator:
                     # The spatial organisation of feature vectors corresponds to the spatial organisation of the tiles.

--- a/ahcore/writers.py
+++ b/ahcore/writers.py
@@ -56,17 +56,16 @@ class H5TileFeatureWriter:
         self._feature_dim: Optional[int] = None
         self._logger = logger
 
-    def init_writer(self, first_features: GenericArray) -> None:
+    def init_writer(self, first_features: GenericArray, h5file) -> None:
         self._feature_dim = first_features.shape[1]
-        with h5py.File("tile_feature_vectors", "w") as h5file:
-            # Create a dataset for feature vectors with shape (wsi_width, wsi_height, feature_dim)
-            self._tile_feature_dataset = h5file.create_dataset(
-                "features",
-                shape=(self._size[0], self._size[1], self._feature_dim),
-                dtype=first_features.dtype,
-                compression="gzip",
-                chunks=(1, 1, self._feature_dim),  # Chunking for each tile
-            )
+        # Create a dataset for feature vectors with shape (wsi_width, wsi_height, feature_dim)
+        self._tile_feature_dataset = h5file.create_dataset(
+            "tile_feature_vectors",
+            shape=(self._size[0], self._size[1], self._feature_dim),
+            dtype=first_features.dtype,
+            compression="gzip",
+            chunks=(1, 1, self._feature_dim),  # Chunking for each tile
+        )
 
     def consume_features(
         self,

--- a/ahcore/writers.py
+++ b/ahcore/writers.py
@@ -259,7 +259,7 @@ class H5FileImageWriter:
         """Adjusts the batch precision based on the precision set in the writer."""
         if self._precision:
             multiplier = self._precision.get_multiplier()
-            batch = batch * multiplier
+            batch = np.multiply(batch, multiplier)
             batch = batch.astype(self._precision.value)
         return batch
 

--- a/ahcore/writers.py
+++ b/ahcore/writers.py
@@ -184,7 +184,7 @@ class H5FileImageWriter:
         # TODO: One would need to collect the coordinates and based on the first and the last
         # TODO: of a single grid, one can determine the grid, and the empty indices.
         if self._grid is None:  # During validation, the grid is passed as a parameter
-            grid = Grid.from_tiling(
+            self._grid = Grid.from_tiling(
                 self._grid_offset,
                 size=self._size,
                 tile_size=self._tile_size,
@@ -192,10 +192,8 @@ class H5FileImageWriter:
                 mode=TilingMode.overflow,
                 order=GridOrder.C,
             )
-        else:
-            grid = self._grid
 
-        num_tiles = len(grid)
+        num_tiles = len(self._grid)
         self._tile_indices = h5file.create_dataset(
             "tile_indices",
             shape=(num_tiles,),

--- a/ahcore/writers.py
+++ b/ahcore/writers.py
@@ -57,7 +57,7 @@ class H5TileFeatureWriter:
         self._feature_dim: Optional[int] = None
         self._logger = logger
 
-    def init_writer(self, first_features: GenericArray, h5file) -> None:
+    def init_writer(self, first_features: GenericArray, h5file: h5py.File) -> None:
         self._feature_dim = first_features.shape[0]
         self._tile_feature_dataset = h5file.create_dataset(
             "tile_feature_vectors",
@@ -100,7 +100,7 @@ class H5TileFeatureWriter:
 
     @staticmethod
     def _feature_generator(
-        first_feature_coordinates, first_features, feature_generator: Generator[Any, None, None]
+        first_feature_coordinates: GenericArray, first_features: GenericArray, feature_generator: Generator[Any, None, None]
     ) -> Generator[Any, None, None]:
         # We plug the first coordinates and the first features back into the generator
         # That way, we can yield them while h5 writing.

--- a/tests/test_writers/test_h5_writer.py
+++ b/tests/test_writers/test_h5_writer.py
@@ -16,7 +16,20 @@ def temp_h5_file(tmp_path: Path) -> Generator[Path, None, None]:
 
 
 def test_h5_file_image_writer(temp_h5_file: Path) -> None:
-    # Test parameters
+    """
+    This test the H5FileImageWriter class for the following case:
+
+    Assuming that we have a tile of size (200, 200) and we want to write it to an H5 file.
+    This test writes the tile to the H5 file and then reads it back to perform assertions.
+
+    Parameters
+    ----------
+    temp_h5_file
+
+    Returns
+    -------
+    None
+    """
     size = (200, 200)
     mpp = 0.5
     tile_size = (200, 200)
@@ -73,6 +86,9 @@ def test_h5_tile_feature_writer(temp_h5_file: Path) -> None:
     ----------
     temp_h5_file : Path
 
+    Returns
+    -------
+    None
     """
     size = (2, 2)
     feature_dimension = 1024

--- a/tests/test_writers/test_h5_writer.py
+++ b/tests/test_writers/test_h5_writer.py
@@ -79,24 +79,24 @@ def test_h5_tile_feature_writer(temp_h5_file):
 
     writer = H5TileFeatureWriter(filename=temp_h5_file, size=size)
 
-    coordinate_list = [(np.array([0, 0]), np.random.rand(feature_dimension)), np.array([0, 1]), np.array([1, 0]), np.array([1, 1])]
-    features = [np.random.rand(feature_dimension), np.random.rand(feature_dimension), np.random.rand(feature_dimension), np.random.rand(feature_dimension)]
+    coords = np.stack([[0, 0], [0, 1], [1, 0], [1, 1]], 0)
+    features = np.random.rand(num_features, feature_dimension)
 
-    # Initialize the writer
-    with h5py.File(temp_h5_file, "w") as h5file:
-        writer.init_writer(np.stack(features, 0), h5file)
-
-    def feature_generator(coordinate_list, features):
-        for coord, feature in zip(coordinate_list, features):
+    def feature_generator(coords, features):
+        for coord, feature in zip(coords, features):
             yield coord, feature
 
     # Write data to the H5 file
-    writer.consume_features(feature_generator(features, coordinate_list))
+    writer.consume_features(feature_generator(coords, features))
 
     # Perform assertions
     with h5py.File(temp_h5_file, "r") as h5file:
         assert "tile_feature_vectors" in h5file
         assert h5file["tile_feature_vectors"].shape == (size[0], size[1], feature_dimension)
+        assert np.allclose(h5file["tile_feature_vectors"][0, 0, :], features[0])
+        assert np.allclose(h5file["tile_feature_vectors"][0, 1, :], features[1])
+        assert np.allclose(h5file["tile_feature_vectors"][1, 0, :], features[2])
+        assert np.allclose(h5file["tile_feature_vectors"][1, 1, :], features[3])
 
 
 # Run the tests

--- a/tests/test_writers/test_h5_writer.py
+++ b/tests/test_writers/test_h5_writer.py
@@ -74,7 +74,7 @@ def test_h5_tile_feature_writer(temp_h5_file: Path) -> None:
 
     Assume that we have an image of size (1024, 1024) tiled up in a batch of 4 tiles of size (512, 512).
     The feature dimension is 1024. So, we have 4 feature vectors of size 1024 which need to be written to the H5 file.
-    We want to do this while retaining their spatial orientation in correspondence with the spatial orientation of the tiles.
+    We retain their spatial orientation in correspondence with the spatial orientation of the tiles.
 
     The features should be written in the following order:
     1. Top left tile   -> Top left feature

--- a/tests/test_writers/test_h5_writer.py
+++ b/tests/test_writers/test_h5_writer.py
@@ -2,7 +2,7 @@ import h5py
 import numpy as np
 import pytest
 
-from ahcore.writers import H5FileImageWriter
+from ahcore.writers import H5FileImageWriter, H5TileFeatureWriter
 
 
 @pytest.fixture
@@ -52,6 +52,57 @@ def test_h5_file_image_writer(temp_h5_file):
         assert "tile_indices" in h5file
         assert "metadata" in h5file.attrs
         # Optionally add more specific assertions here
+
+
+def test_h5_tile_feature_writer(temp_h5_file):
+    """
+    This test the H5TileFeatureWriter class for the following case.
+
+    Assume that we have an image of size (1024, 1024) tiled up in a batch of 4 tiles of size (512, 512).
+    The feature dimension is 1024. So, we have 4 feature vectors of size 1024 which need to be written to the H5 file.
+    We want to do this while retaining their spatial orientation in correspondence with the spatial orientation of the tiles.
+
+    The features should be written in the following order:
+    1. Top left tile   -> Top left feature
+    2. Top right tile  -> Top right feature
+    3. Bottom left tile -> Bottom left feature
+    4. Bottom right tile -> Bottom right feature
+
+    Parameters
+    ----------
+    temp_h5_file : Path
+
+    """
+    size = (2, 2)
+    feature_dimension = 1024
+    num_features = 4
+
+    writer = H5TileFeatureWriter(filename=temp_h5_file, size=size)
+
+    coordinate_list = [np.array([0, 0]), np.array([0, 1]), np.array([1, 0]), np.array([1, 1])]
+    features = np.random.rand(num_features , feature_dimension)
+
+    # Initialize the writer
+    with h5py.File(temp_h5_file, "w") as h5file:
+        writer.init_writer(features, h5file)
+
+    def feature_generator(features, coordinate_list):
+        for coord, feature in zip(coordinate_list, features):
+            yield (coord, feature)
+
+    # Write data to the H5 file
+    writer.consume_features(feature_generator(features, coordinate_list))
+
+    # Perform assertions
+    with h5py.File(temp_h5_file, "r") as h5file:
+        assert "tile_feature_vectors" in h5file
+        assert h5file["tile_feature_vectors"].shape == (size[0], size[1], feature_dimension)
+        print(h5file["tile_feature_vectors"][0, 0, :])
+        print(features[0])
+        assert np.allclose(h5file["tile_feature_vectors"][0, 0, :], features[0])
+        assert np.allclose(h5file["tile_feature_vectors"][0, 1, :], features[1])
+        assert np.allclose(h5file["tile_feature_vectors"][1, 0, :], features[2])
+        assert np.allclose(h5file["tile_feature_vectors"][1, 1, :], features[3])
 
 
 # Run the tests

--- a/tests/test_writers/test_h5_writer.py
+++ b/tests/test_writers/test_h5_writer.py
@@ -1,17 +1,21 @@
+from pathlib import Path
+from typing import Generator
+
 import h5py
 import numpy as np
 import pytest
 
+from ahcore.utils.types import GenericArray
 from ahcore.writers import H5FileImageWriter, H5TileFeatureWriter
 
 
 @pytest.fixture
-def temp_h5_file(tmp_path):
+def temp_h5_file(tmp_path: Path) -> Generator[Path, None, None]:
     h5_file_path = tmp_path / "test_data.h5"
     yield h5_file_path
 
 
-def test_h5_file_image_writer(temp_h5_file):
+def test_h5_file_image_writer(temp_h5_file: Path) -> None:
     # Test parameters
     size = (1000, 800)
     mpp = 0.5
@@ -38,9 +42,9 @@ def test_h5_file_image_writer(temp_h5_file):
         writer.init_writer(dummy_coordinates, dummy_batch, h5file)
 
     # Use a generator to yield dummy batches
-    def batch_generator():
+    def batch_generator() -> Generator[tuple[GenericArray, GenericArray], None, None]:
         for i in range(num_samples):
-            yield (dummy_coordinates, dummy_batch)
+            yield dummy_coordinates, dummy_batch
 
     # Write data to the H5 file
     writer.consume(batch_generator())
@@ -54,7 +58,7 @@ def test_h5_file_image_writer(temp_h5_file):
         # Optionally add more specific assertions here
 
 
-def test_h5_tile_feature_writer(temp_h5_file):
+def test_h5_tile_feature_writer(temp_h5_file: Path) -> None:
     """
     This test the H5TileFeatureWriter class for the following case.
 
@@ -82,7 +86,9 @@ def test_h5_tile_feature_writer(temp_h5_file):
     coords = np.stack([[0, 0], [0, 1], [1, 0], [1, 1]], 0)
     features = np.random.rand(num_features, feature_dimension)
 
-    def feature_generator(coords, features):
+    def feature_generator(
+        coords: GenericArray, features: GenericArray
+    ) -> Generator[tuple[GenericArray, GenericArray], None, None]:
         for coord, feature in zip(coords, features):
             yield coord, feature
 

--- a/tests/test_writers/test_h5_writer.py
+++ b/tests/test_writers/test_h5_writer.py
@@ -17,11 +17,11 @@ def temp_h5_file(tmp_path: Path) -> Generator[Path, None, None]:
 
 def test_h5_file_image_writer(temp_h5_file: Path) -> None:
     # Test parameters
-    size = (1000, 800)
+    size = (200, 200)
     mpp = 0.5
     tile_size = (200, 200)
-    tile_overlap = (50, 50)
-    num_samples = 10
+    tile_overlap = (0, 0)
+    num_samples = 1
 
     # Create an instance of H5FileImageWriter
     writer = H5FileImageWriter(
@@ -34,12 +34,8 @@ def test_h5_file_image_writer(temp_h5_file: Path) -> None:
     )
 
     # Dummy batch data for testing
-    dummy_coordinates = np.random.randint(0, 255, (10, 2))
-    dummy_batch = np.random.rand(10, 3, 200, 200)
-
-    # Initialize the writer
-    with h5py.File(temp_h5_file, "w") as h5file:
-        writer.init_writer(dummy_coordinates, dummy_batch, h5file)
+    dummy_coordinates = np.random.randint(0, 255, (1, 2))
+    dummy_batch = np.random.rand(1, 3, 200, 200)
 
     # Use a generator to yield dummy batches
     def batch_generator() -> Generator[tuple[GenericArray, GenericArray], None, None]:
@@ -53,9 +49,10 @@ def test_h5_file_image_writer(temp_h5_file: Path) -> None:
     with h5py.File(temp_h5_file, "r") as h5file:
         assert "data" in h5file
         assert "coordinates" in h5file
-        assert "tile_indices" in h5file
-        assert "metadata" in h5file.attrs
-        # Optionally add more specific assertions here
+        assert h5file["data"].shape == (num_samples, 3, 200, 200)
+        assert h5file["coordinates"].shape == (num_samples, 2)
+        assert np.allclose(h5file["data"], dummy_batch)
+        assert np.allclose(h5file["coordinates"], dummy_coordinates)
 
 
 def test_h5_tile_feature_writer(temp_h5_file: Path) -> None:

--- a/tests/test_writers/test_h5_writer.py
+++ b/tests/test_writers/test_h5_writer.py
@@ -79,16 +79,16 @@ def test_h5_tile_feature_writer(temp_h5_file):
 
     writer = H5TileFeatureWriter(filename=temp_h5_file, size=size)
 
-    coordinate_list = [np.array([0, 0]), np.array([0, 1]), np.array([1, 0]), np.array([1, 1])]
-    features = np.random.rand(num_features , feature_dimension)
+    coordinate_list = [(np.array([0, 0]), np.random.rand(feature_dimension)), np.array([0, 1]), np.array([1, 0]), np.array([1, 1])]
+    features = [np.random.rand(feature_dimension), np.random.rand(feature_dimension), np.random.rand(feature_dimension), np.random.rand(feature_dimension)]
 
     # Initialize the writer
     with h5py.File(temp_h5_file, "w") as h5file:
-        writer.init_writer(features, h5file)
+        writer.init_writer(np.stack(features, 0), h5file)
 
-    def feature_generator(features, coordinate_list):
+    def feature_generator(coordinate_list, features):
         for coord, feature in zip(coordinate_list, features):
-            yield (coord, feature)
+            yield coord, feature
 
     # Write data to the H5 file
     writer.consume_features(feature_generator(features, coordinate_list))
@@ -97,12 +97,6 @@ def test_h5_tile_feature_writer(temp_h5_file):
     with h5py.File(temp_h5_file, "r") as h5file:
         assert "tile_feature_vectors" in h5file
         assert h5file["tile_feature_vectors"].shape == (size[0], size[1], feature_dimension)
-        print(h5file["tile_feature_vectors"][0, 0, :])
-        print(features[0])
-        assert np.allclose(h5file["tile_feature_vectors"][0, 0, :], features[0])
-        assert np.allclose(h5file["tile_feature_vectors"][0, 1, :], features[1])
-        assert np.allclose(h5file["tile_feature_vectors"][1, 0, :], features[2])
-        assert np.allclose(h5file["tile_feature_vectors"][1, 1, :], features[3])
 
 
 # Run the tests


### PR DESCRIPTION
This PR adds:

1. `H5TileFeatureWriter` to write feature vectors of WSI tiles to h5 files. 
2. The spatial configuration of the feature vectors correspond to the spatial configuration of their respective tiles in the WSI. Check below for a visual representation.
![image](https://github.com/NKI-AI/ahcore/assets/26798611/6dc04d0e-7b0c-44a2-a8bf-48966d144537)

3. A test to check the new writer and its functions.
4. This issue fixes #53 