### PR TITLE
Fixes #57

### DIFF
--- a/ahcore/callbacks/h5_callback.py
+++ b/ahcore/callbacks/h5_callback.py
@@ -23,8 +23,8 @@ class WriteH5Callback(Callback):
         max_queue_size: int,
         max_concurrent_writers: int,
         dump_dir: Path,
-        normalization_type: str = str(NormalizationType.LOGITS),
-        precision: str = str(InferencePrecision.FP32),
+        normalization_type: str = NormalizationType.LOGITS,
+        precision: str = InferencePrecision.FP32,
     ):
         """
         Callback to write predictions to H5 files. This callback is used to write whole-slide predictions to single H5


### PR DESCRIPTION
Fixes #57.

There was a minor issue in the initialization of `H5FileImageWriter`. I removed the explicit type casting that was in place for `NormalizationType` and `InferencePrecision`. Rest of the functionalities remain the same.
