### PR TITLE
Fix CI/CD

### DIFF
--- a/.github/workflows/precommit_checks.yml
+++ b/.github/workflows/precommit_checks.yml
@@ -39,9 +39,9 @@ jobs:
             # Determine which python files have changed in the PR.
             - name: Get Changed Files
               id: changed-files
-              uses: tj-actions/changed-files@v36
+              uses: tj-actions/changed-files@v42
               with:
-                files: '*.py'
+                files: '**/*.py'
 
             # Run the precommit hooks only on the changed files.
             - name: Execute Precommit Hooks on Changed Files in PR


### PR DESCRIPTION
The glob pattern `*.py` was only looking in the main directory of the repository, this changes it to also consider any subfolders for python files. Also updated to latest version.