### PR TITLE
Implement `ignore_index` in metrics

### DIFF
--- a/config/callbacks/write_file_callback.yaml
+++ b/config/callbacks/write_file_callback.yaml
@@ -18,4 +18,6 @@ write_file_callback:
       reader_class:
         _target_: ahcore.readers.ZarrFileImageReader
         _partial_: true
+      max_concurrent_tasks: 3
+      ignore_index: null
   max_concurrent_queues: 3

--- a/config/metrics/segmentation.yaml
+++ b/config/metrics/segmentation.yaml
@@ -1,6 +1,8 @@
 tile_level:
   _target_: ahcore.metrics.MetricFactory.for_segmentation
+  ignore_index: null
 
 wsi_level:
   _target_: ahcore.metrics.WSIMetricFactory.for_segmentation
   compute_overall_dice: True
+  ignore_index: null


### PR DESCRIPTION
Fixes #94 

Now, We can choose which indices to ignore while displaying the metrics on tensorboard
