### PR TITLE
Add offset to writer metadata

### DIFF
--- a/ahcore/backends.py
+++ b/ahcore/backends.py
@@ -31,7 +31,7 @@ class ZarrSlide(AbstractSlideBackend):
 
     @property
     def properties(self) -> dict[str, Any]:
-        return self._reader._metadata
+        return self._reader.metadata
 
     @property
     def magnification(self):

--- a/ahcore/callbacks/milvus_vector_db_callback.py
+++ b/ahcore/callbacks/milvus_vector_db_callback.py
@@ -63,9 +63,9 @@ class MilvusVectorDBCallback(Callback):
         self._collection_name = collection_name
         self._collection_type = CollectionType[collection_type.upper()]
         self._collection: Collection | None = None
-        self._prepare_data: Callable[
-            [Dict[str, Any], Dict[str, Any]], PrepareDataTypePathCLS | PrepareDataTypeDebug
-        ] | None = None
+        self._prepare_data: (
+            Callable[[Dict[str, Any], Dict[str, Any]], PrepareDataTypePathCLS | PrepareDataTypeDebug] | None
+        ) = None
 
         self.embedding_dim = embedding_dim
 

--- a/ahcore/data/dataset.py
+++ b/ahcore/data/dataset.py
@@ -88,10 +88,12 @@ class ConcatDataset(Dataset[DlupDatasetSample]):
         return self.cumulative_sizes[-1]
 
     @overload
-    def __getitem__(self, index: int) -> DlupDatasetSample: ...
+    def __getitem__(self, index: int) -> DlupDatasetSample:
+        ...
 
     @overload
-    def __getitem__(self, index: slice) -> list[DlupDatasetSample]: ...
+    def __getitem__(self, index: slice) -> list[DlupDatasetSample]:
+        ...
 
     def __getitem__(self, index: Union[int, slice]) -> DlupDatasetSample | list[DlupDatasetSample]:
         """Returns the sample at the given index."""

--- a/ahcore/readers.py
+++ b/ahcore/readers.py
@@ -149,6 +149,13 @@ class FileImageReader(abc.ABC):
         self.__empty_tile = np.zeros((self._num_channels, *self._tile_size), dtype=self._dtype)
         return self.__empty_tile
 
+    @property
+    def metadata(self) -> dict[str, Any]:
+        if not self._metadata:
+            self._open_file()
+            assert self._metadata
+        return self._metadata
+
     def _decompress_data(self, tile: GenericNumberArray) -> GenericNumberArray:
         if self._is_binary:
             with PIL.Image.open(io.BytesIO(tile)) as img:
@@ -156,7 +163,7 @@ class FileImageReader(abc.ABC):
         else:
             return tile
 
-    def read_region(self, location: tuple[int, int], level: int, size: tuple[int, int]) -> GenericNumberArray:
+    def read_region(self, location: tuple[int, int], level: int, size: tuple[int, int]) -> pyvips.Image:
         """
         Reads a region in the stored h5 file. This function stitches the regions as saved in the cache file. Doing this
         it takes into account:

--- a/ahcore/utils/callbacks.py
+++ b/ahcore/utils/callbacks.py
@@ -1,7 +1,7 @@
 """Ahcore's callbacks"""
 
 from __future__ import annotations
-import pyvips
+
 import hashlib
 import logging
 from pathlib import Path
@@ -9,6 +9,7 @@ from typing import Any, Iterator, Optional
 
 import numpy as np
 import numpy.typing as npt
+import pyvips
 from dlup import SlideImage
 from dlup.annotations import WsiAnnotations
 from dlup.data.transforms import convert_annotations, rename_labels
@@ -138,7 +139,7 @@ class _ValidationDataset(Dataset[DlupDatasetSample]):
         sample = {}
         coordinates = self._regions[idx]
 
-        sample["prediction"] = self._get_h5_region(coordinates)
+        sample["prediction"] = self._get_backend_file_region(coordinates)
 
         if self._annotations is not None:
             target, roi = self._get_annotation_data(coordinates)
@@ -150,7 +151,7 @@ class _ValidationDataset(Dataset[DlupDatasetSample]):
 
         return sample
 
-    def _get_h5_region(self, coordinates: tuple[int, int]) -> npt.NDArray[np.uint8 | np.uint16 | np.float32 | np.bool_]:
+    def _get_backend_file_region(self, coordinates: tuple[int, int]) -> pyvips.Image:
         x, y = coordinates
         width, height = self._region_size
 

--- a/ahcore/utils/database_models.py
+++ b/ahcore/utils/database_models.py
@@ -202,7 +202,7 @@ class Split(Base):
     # pylint: disable=E1102
     created = Column(DateTime(timezone=True), default=func.now())
     last_updated = Column(DateTime(timezone=True), default=func.now(), onupdate=func.now())
-    category: Column[CategoryEnum] = Column(Enum(CategoryEnum), nullable=False)
+    category: Column[str] = Column(Enum(CategoryEnum), nullable=False)
     patient_id = Column(Integer, ForeignKey("patient.id"), nullable=False)
     split_definition_id = Column(Integer, ForeignKey("split_definitions.id"), nullable=False)
 

--- a/ahcore/utils/io.py
+++ b/ahcore/utils/io.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import logging
 import os
 import pathlib
+import subprocess
 import warnings
 from enum import Enum
 from pathlib import Path
@@ -273,3 +274,19 @@ def validate_checkpoint_paths(config: DictConfig) -> DictConfig:
         if checkpoint_path and not os.path.isabs(checkpoint_path):
             config.trainer.resume_from_checkpoint = pathlib.Path(hydra.utils.get_original_cwd()) / checkpoint_path
         return config
+
+
+def get_git_hash():
+    try:
+        # Check if we're in a git repository
+        subprocess.run(["git", "rev-parse", "--is-inside-work-tree"], check=True, capture_output=True, text=True)
+
+        # Get the git hash
+        result = subprocess.run(["git", "rev-parse", "HEAD"], check=True, capture_output=True, text=True)
+        return result.stdout.strip()
+    except subprocess.CalledProcessError:
+        # This will be raised if we're not in a git repo
+        return None
+    except FileNotFoundError:
+        # This will be raised if git is not installed or not in PATH
+        return None

--- a/ahcore/writers.py
+++ b/ahcore/writers.py
@@ -15,6 +15,7 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Generator, NamedTuple, Optional
 
+import dlup
 import h5py
 import numcodecs
 import numpy as np
@@ -23,6 +24,7 @@ import PIL.Image
 import zarr
 from dlup.tiling import Grid, GridOrder, TilingMode
 
+import ahcore
 from ahcore.utils.io import get_logger
 from ahcore.utils.types import GenericNumberArray, InferencePrecision
 
@@ -66,6 +68,7 @@ class WriterMetadata(NamedTuple):
     num_channels: int
     dtype: str
     grid_offset: tuple[int, int] | None
+    version: str
 
 
 class Writer(abc.ABC):
@@ -175,7 +178,12 @@ class Writer(abc.ABC):
         _dtype = str(first_batch.dtype)
 
         return WriterMetadata(
-            mode=_mode, format=_format, num_channels=_num_channels, dtype=_dtype, grid_offset=self._grid_offset
+            mode=_mode,
+            format=_format,
+            num_channels=_num_channels,
+            dtype=_dtype,
+            grid_offset=self._grid_offset,
+            version=f"dlup version {dlup.__version__}; ahcore version {ahcore.__version__}",
         )
 
     def set_grid(self) -> None:

--- a/ahcore/writers.py
+++ b/ahcore/writers.py
@@ -222,7 +222,7 @@ class Writer(abc.ABC):
             "format": writer_metadata.format,
             "dtype": writer_metadata.dtype,
             "is_binary": self._is_compressed_image,
-            "offset": writer_metadata.grid_offset,
+            "grid_offset": writer_metadata.grid_offset,
             "precision": self._precision.value if self._precision else str(InferencePrecision.FP32),
             "multiplier": (
                 self._precision.get_multiplier() if self._precision else InferencePrecision.FP32.get_multiplier()

--- a/ahcore/writers.py
+++ b/ahcore/writers.py
@@ -25,7 +25,7 @@ import zarr
 from dlup.tiling import Grid, GridOrder, TilingMode
 
 import ahcore
-from ahcore.utils.io import get_logger
+from ahcore.utils.io import get_git_hash, get_logger
 from ahcore.utils.types import GenericNumberArray, InferencePrecision
 
 logger = get_logger(__name__)
@@ -68,7 +68,7 @@ class WriterMetadata(NamedTuple):
     num_channels: int
     dtype: str
     grid_offset: tuple[int, int] | None
-    version: str
+    versions: dict[str, str]
 
 
 class Writer(abc.ABC):
@@ -183,7 +183,7 @@ class Writer(abc.ABC):
             num_channels=_num_channels,
             dtype=_dtype,
             grid_offset=self._grid_offset,
-            version=f"dlup version {dlup.__version__}; ahcore version {ahcore.__version__}",
+            versions={"dlup": dlup.__version__, "ahcore": ahcore.__version__, "ahcore_git_hash": get_git_hash()},
         )
 
     def set_grid(self) -> None:

--- a/ahcore/writers.py
+++ b/ahcore/writers.py
@@ -222,6 +222,7 @@ class Writer(abc.ABC):
             "format": writer_metadata.format,
             "dtype": writer_metadata.dtype,
             "is_binary": self._is_compressed_image,
+            "offset": writer_metadata.grid_offset,
             "precision": self._precision.value if self._precision else str(InferencePrecision.FP32),
             "multiplier": (
                 self._precision.get_multiplier() if self._precision else InferencePrecision.FP32.get_multiplier()

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,14 +3,14 @@ current_version = 0.1.1
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<build>\d+))?
-serialize = 
+serialize =
 	{major}.{minor}.{patch}-{release}{build}
 	{major}.{minor}.{patch}
 
 [bumpversion:part:release]
 optional_value = prod
 first_value = dev
-values = 
+values =
 	dev
 	prod
 

--- a/tests/test_readers/test_readers.py
+++ b/tests/test_readers/test_readers.py
@@ -1,16 +1,16 @@
 import errno
 import os
 from pathlib import Path
-from typing import Generator, Any
+from typing import Any, Generator
 from unittest.mock import patch
 
 import h5py
 import numpy as np
+import numpy.typing as npt
 import pytest
 
 from ahcore.readers import FileImageReader, StitchingMode
 from ahcore.utils.types import GenericNumberArray
-import numpy.typing as npt
 
 
 def colorize(image_array: npt.NDArray[np.uint8]) -> npt.NDArray[np.uint8]:
@@ -204,7 +204,7 @@ def test_stitching_modes(temp_h5_file: Path) -> None:
 
         with patch("pyvips.Image.new_from_array") as mock_pyvips:
             # Reading a region that covers all 4 tiles
-            region = reader.read_region((0, 0), 0, (350, 350))
+            _ = reader.read_region((0, 0), 0, (350, 350))
             mock_pyvips.assert_called_once()
 
             stitched_image = mock_pyvips.call_args[0][0]

--- a/tests/test_writers/test_h5_writer.py
+++ b/tests/test_writers/test_h5_writer.py
@@ -1,11 +1,12 @@
+import json
 from pathlib import Path
-from typing import Generator
+from typing import Any, Generator
 
 import h5py
 import numpy as np
 import pytest
 
-from ahcore.utils.types import GenericNumberArray
+from ahcore.utils.types import GenericNumberArray, InferencePrecision
 from ahcore.writers import H5FileImageWriter
 
 
@@ -13,30 +14,34 @@ from ahcore.writers import H5FileImageWriter
 def temp_h5_file(tmp_path: Path) -> Generator[Path, None, None]:
     h5_file_path = tmp_path / "test_data.h5"
     yield h5_file_path
+    if h5_file_path.exists():
+        h5_file_path.unlink()
 
 
-def test_h5_file_image_writer(temp_h5_file: Path) -> None:
-    """
-    This test the H5FileImageWriter class for the following case:
+@pytest.fixture
+def dummy_batch_data() -> Generator[tuple[GenericNumberArray, GenericNumberArray], None, None]:
+    dummy_coordinates = np.array([[0, 0]])
+    dummy_batch = np.random.rand(1, 3, 200, 200).astype(np.float32)
+    yield dummy_coordinates, dummy_batch
 
-    Assuming that we have a tile of size (200, 200) and we want to write it to an H5 file.
-    This test writes the tile to the H5 file and then reads it back to perform assertions.
 
-    Parameters
-    ----------
-    temp_h5_file
+@pytest.fixture
+def dummy_batch_generator(
+    dummy_batch_data: tuple[GenericNumberArray, GenericNumberArray]
+) -> Generator[tuple[GenericNumberArray, GenericNumberArray], None, None]:
+    def generator() -> Generator[tuple[GenericNumberArray, GenericNumberArray], None, None]:
+        yield dummy_batch_data
 
-    Returns
-    -------
-    None
-    """
+    return generator
+
+
+def test_h5_file_image_writer_creation(temp_h5_file: Path) -> None:
     size = (200, 200)
     mpp = 0.5
     tile_size = (200, 200)
     tile_overlap = (0, 0)
     num_samples = 1
 
-    # Create an instance of H5FileImageWriter
     writer = H5FileImageWriter(
         filename=temp_h5_file,
         size=size,
@@ -46,28 +51,117 @@ def test_h5_file_image_writer(temp_h5_file: Path) -> None:
         num_samples=num_samples,
     )
 
-    # Dummy batch data for testing
-    dummy_coordinates = np.random.randint(0, 255, (1, 2))
-    dummy_batch = np.random.rand(1, 3, 200, 200)
+    assert writer._filename == temp_h5_file
+    assert writer._size == size
+    assert writer._mpp == mpp
+    assert writer._tile_size == tile_size
+    assert writer._tile_overlap == tile_overlap
+    assert writer._num_samples == num_samples
 
-    # Use a generator to yield dummy batches
-    def batch_generator() -> Generator[tuple[GenericNumberArray, GenericNumberArray], None, None]:
-        for i in range(num_samples):
-            yield dummy_coordinates, dummy_batch
 
-    # Write data to the H5 file
-    writer.consume(batch_generator())
+def test_h5_file_image_writer_consume(temp_h5_file: Path, dummy_batch_generator: Any) -> None:
+    size = (200, 200)
+    mpp = 0.5
+    tile_size = (200, 200)
+    tile_overlap = (0, 0)
+    num_samples = 1
 
-    # Perform assertions
+    writer = H5FileImageWriter(
+        filename=temp_h5_file,
+        size=size,
+        mpp=mpp,
+        tile_size=tile_size,
+        tile_overlap=tile_overlap,
+        num_samples=num_samples,
+    )
+
+    writer.consume(dummy_batch_generator())
+
     with h5py.File(temp_h5_file, "r") as h5file:
         assert "data" in h5file
         assert "coordinates" in h5file
         assert np.array(h5file["data"]).shape == (num_samples, 3, 200, 200)
         assert np.array(h5file["coordinates"]).shape == (num_samples, 2)
+
+        dummy_coordinates, dummy_batch = next(dummy_batch_generator())
         assert np.allclose(h5file["data"], dummy_batch)
         assert np.allclose(h5file["coordinates"], dummy_coordinates)
 
 
-# Run the tests
-if __name__ == "__main__":
-    pytest.main()
+def test_h5_file_image_writer_metadata(temp_h5_file: Path, dummy_batch_generator: Any) -> None:
+    size = (200, 200)
+    mpp = 0.5
+    tile_size = (200, 200)
+    tile_overlap = (0, 0)
+    num_samples = 1
+    num_tiles = 1
+    grid_order = "C"
+    tiling_mode = "overflow"
+    format = "RAW"
+    dtype = "float32"
+    is_binary = False
+    grid_offset = (0, 0)
+    precision = InferencePrecision.FP32
+    multiplier = 1.0
+
+    writer = H5FileImageWriter(
+        filename=temp_h5_file,
+        size=size,
+        mpp=mpp,
+        tile_size=tile_size,
+        tile_overlap=tile_overlap,
+        num_samples=num_samples,
+        precision=precision,
+    )
+
+    writer.consume(dummy_batch_generator())
+
+    with h5py.File(temp_h5_file, "r") as h5file:
+        metadata = json.loads(h5file.attrs["metadata"])
+        assert metadata["size"] == list(size)
+        assert metadata["mpp"] == mpp
+        assert metadata["num_samples"] == num_samples
+        assert metadata["tile_size"] == list(tile_size)
+        assert metadata["tile_overlap"] == list(tile_overlap)
+        assert metadata["num_tiles"] == num_tiles
+        assert metadata["grid_order"] == grid_order
+        assert metadata["tiling_mode"] == tiling_mode
+        assert metadata["format"] == format
+        assert metadata["dtype"] == dtype
+        assert metadata["is_binary"] == is_binary
+        assert metadata["grid_offset"] == list(grid_offset)
+        assert metadata["precision"] == precision
+        assert metadata["multiplier"] == multiplier
+
+
+def test_h5_file_image_writer_multiple_tiles(temp_h5_file: Path) -> None:
+    size = (400, 400)
+    mpp = 0.5
+    tile_size = (200, 200)
+    tile_overlap = (0, 0)
+    num_samples = 2
+
+    writer = H5FileImageWriter(
+        filename=temp_h5_file,
+        size=size,
+        mpp=mpp,
+        tile_size=tile_size,
+        tile_overlap=tile_overlap,
+        num_samples=num_samples,
+    )
+
+    def multiple_tile_generator() -> Generator[tuple[GenericNumberArray, GenericNumberArray], None, None]:
+        for i in range(num_samples):
+            coordinates = np.array([[i * 200, 0]])
+            batch = np.random.rand(1, 3, 200, 200).astype(np.float32)
+            yield coordinates, batch
+
+    writer.consume(multiple_tile_generator())
+
+    with h5py.File(temp_h5_file, "r") as h5file:
+        assert "data" in h5file
+        assert "coordinates" in h5file
+        assert h5file["data"].shape == (num_samples, 3, 200, 200)
+        assert h5file["coordinates"].shape == (num_samples, 2)
+        for i in range(num_samples):
+            assert np.allclose(h5file["coordinates"][i], [i * 200, 0])


### PR DESCRIPTION
This PR implements an offset into the writers. This is required as some WSI provide bounds which should be used to find the 'valid' region of the image. The writer extracts the first coordinate to construct a grid, but to reconstruct the image the offset is required.

Once merged, the reader can be made to accommodate for this