### PR TITLE
Fix grid during validation callback

### DIFF
--- a/ahcore/writers.py
+++ b/ahcore/writers.py
@@ -314,7 +314,12 @@ class Writer(abc.ABC):
 
     def init_writer(self, first_coordinates: GenericNumberArray, first_batch: GenericNumberArray, file: Any) -> Any:
         """Initializes the image_dataset based on the first tile."""
-        self._grid_offset = (int(first_coordinates[0][0]), int(first_coordinates[0][1]))
+        if self._grid is None:
+            # If the grid is not given to the constructor, we take the first element of the coordinates as the offset.
+            self._grid_offset = (int(first_coordinates[0][0]), int(first_coordinates[0][1]))
+        else:
+            # If the grid is given to the constructor, we take the first element of the grid as the offset.
+            self._grid_offset = tuple(self._grid[0])
 
         writer_metadata = self.get_writer_metadata(first_batch)
 


### PR DESCRIPTION
Fixes #107 

This PR fixes the issue described above that led to the misalignment of annotations/masks with the cached image during validation. Due to this misalignment, the validation metrics were not relibale or in some cases, when there were no "masked" regions available - the callback simply crashed.

For now, these fixes will work but the [_ValidationDataset](https://github.com/NKI-AI/ahcore/blob/a8b5829901ff2c178bbf051e25e18c1b037ef2f8/ahcore/utils/callbacks.py#L49) as it is implemented now in ahcore should be replaced with dlup dataset.