### PR TITLE
fix remaining mypy errors and mistake in test suite

### DIFF
--- a/ahcore/cli/tiling.py
+++ b/ahcore/cli/tiling.py
@@ -20,11 +20,15 @@ import numpy.typing as npt
 import PIL.Image
 import PIL.ImageCms
 from dlup import SlideImage
-from dlup.backends import ImageBackend  # type: ignore  # pylint: disable=no-name-in-module
 from dlup.data.dataset import TiledWsiDataset
 from dlup.tiling import GridOrder, TilingMode
+from dlup.utils.backends import ImageBackend
 from PIL import Image
-from PIL.ImageCms import ImageCmsProfile
+from PIL.ImageCms import (  # type: ignore  # types-Pillow is not up to date with pillow 10.4
+    Flags,
+    ImageCmsProfile,
+    Intent,
+)
 from pydantic import BaseModel
 from rich.progress import Progress
 
@@ -159,9 +163,9 @@ def _save_thumbnail(
         # If the color_profile is applied to the filtered tiles, apply it to the thumbnail too
         if dataset_cfg.color_profile_applied and slide_image.color_profile:
             to_profile = PIL.ImageCms.createProfile("sRGB")
-            intent = PIL.ImageCms.getDefaultIntent(ImageCmsProfile(slide_image.color_profile))  # type: ignore
+            intent = Intent(PIL.ImageCms.getDefaultIntent(ImageCmsProfile(slide_image.color_profile)))  # type: ignore
             rgb_color_transform = PIL.ImageCms.buildTransform(
-                ImageCmsProfile(slide_image.color_profile), to_profile, "RGB", "RGB", intent, 0
+                ImageCmsProfile(slide_image.color_profile), to_profile, "RGB", "RGB", intent, Flags.NONE
             )
             PIL.ImageCms.applyTransform(thumbnail, rgb_color_transform, True)
 

--- a/tests/test_readers/test_readers.py
+++ b/tests/test_readers/test_readers.py
@@ -50,6 +50,8 @@ def create_colored_tiles(
 
 
 class TestFileImageReader(FileImageReader):
+    __test__ = False
+
     def _open_file_handle(self, filename: Path) -> h5py.File:
         return h5py.File(filename, "r")
 


### PR DESCRIPTION
Note that non-test classes cannot be named Test... in a test suite since pytest will assume it's a test.

The types-Pillow package is stuck at 10.2 and is therefore inconsistent with the most recent Pillow version (10.4). As a result, some type ignore hints have to be added and may be removed in a future version.

All pre-commit checks and tests should now pass without warnings and/or errors.